### PR TITLE
Restrict Job data returned depending on logged in user

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/rails-api/active_model_serializers.git
-  revision: f2d59b20caa52244f907aa607bf7d8827c46cb7f
+  revision: f32c0d97d5a3a609979b57655e107f678470fdaa
   specs:
-    active_model_serializers (0.10.0.rc3)
+    active_model_serializers (0.10.0.rc4)
       actionpack (>= 4.0)
       activemodel (>= 4.0)
       railties (>= 4.0)

--- a/app/controllers/api/v1/skills_controller.rb
+++ b/app/controllers/api/v1/skills_controller.rb
@@ -25,6 +25,7 @@ module Api
       example Doxxer.example_for(Skill)
       def show
         authorize(@skill)
+
         render json: @skill, include: ['language']
       end
 

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -29,6 +29,19 @@ class JobPolicy < ApplicationPolicy
     end
   end
 
+  def present_applicants?
+    admin? || owner?
+  end
+
+  def present_attributes
+    attributes = record.attribute_names.map(&:to_sym)
+    if admin? || owner? || accepted_applicant?
+      attributes
+    else
+      attributes - [:latitude, :longitude, :performed, :performed_accept]
+    end
+  end
+
   # Methods that don't match any controller action
 
   def owner?

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -33,6 +33,10 @@ class JobPolicy < ApplicationPolicy
     admin? || owner?
   end
 
+  def present_self_applicant?
+    accepted_applicant?
+  end
+
   def present_attributes
     attributes = record.attribute_names.map(&:to_sym)
     if admin? || owner? || accepted_applicant?

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -1,4 +1,13 @@
 class JobPolicy < ApplicationPolicy
+  PRIVILEGE_ATTRIBUTES = [:latitude, :longitude, :performed, :performed_accept].freeze
+
+  OWNER_PARAMS = [
+    :max_rate, :performed_accept, :description, :job_date, :street, :zip,
+    :name, :hours, :language_id, skill_ids: []
+  ].freeze
+  ACCEPTED_APPLICANT_PARAMS = [:performed].freeze
+  ADMIN_PARAMS = (OWNER_PARAMS + ACCEPTED_APPLICANT_PARAMS).freeze
+
   def index?
     true
   end
@@ -19,11 +28,11 @@ class JobPolicy < ApplicationPolicy
 
   def permitted_attributes
     if admin?
-      admin_params
+      ADMIN_PARAMS
     elsif !record.persisted? || owner?
-      owner_params
+      OWNER_PARAMS
     elsif accepted_applicant?
-      accepted_applicant_params
+      ACCEPTED_APPLICANT_PARAMS
     else
       []
     end
@@ -42,7 +51,7 @@ class JobPolicy < ApplicationPolicy
     if admin? || owner? || accepted_applicant?
       attributes
     else
-      attributes - [:latitude, :longitude, :performed, :performed_accept]
+      attributes - PRIVILEGE_ATTRIBUTES
     end
   end
 
@@ -54,22 +63,5 @@ class JobPolicy < ApplicationPolicy
 
   def accepted_applicant?
     record.accepted_applicant?(user)
-  end
-
-  private
-
-  def admin_params
-    owner_params + accepted_applicant_params
-  end
-
-  def owner_params
-    [
-      :max_rate, :performed_accept, :description, :job_date, :street, :zip,
-      :name, :hours, :language_id, skill_ids: []
-    ]
-  end
-
-  def accepted_applicant_params
-    [:performed]
   end
 end

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -33,12 +33,10 @@ class JobSerializer < ActiveModel::Serializer
   def applicant_records
     if policy.present_applicants?
       object.users
+    elsif present_self_applicant?
+      [current_user]
     else
-      if object.accepted_applicant?(current_user)
-        [current_user]
-      else
-        User.none
-      end
+      User.none
     end
   end
 

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -33,7 +33,7 @@ class JobSerializer < ActiveModel::Serializer
   def applicant_records
     if policy.present_applicants?
       object.users
-    elsif present_self_applicant?
+    elsif policy.present_self_applicant?
       [current_user]
     else
       User.none

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -1,13 +1,50 @@
 class JobSerializer < ActiveModel::Serializer
-  attributes :id, :max_rate, :description, :job_date, :created_at, :updated_at,
+  attributes :id, :description, :job_date, :created_at, :updated_at,
              :performed_accept, :performed, :longitude, :latitude, :name,
              :hours, :zip, :zip_latitude, :zip_longitude
 
-  has_many :users, key: :applicants
+  has_many :users, key: :applicants do
+    # Doxxer invokes the serializer on non-persisted objects,
+    # so we need to check if the record is persisted
+    if object.persisted?
+      applicant_records
+    else
+      User.none
+    end
+  end
   has_many :comments
 
   has_one :owner
   has_one :language
+
+  def attributes(_)
+    data = super
+    # Doxxer invokes the serializer on non-persisted objects,
+    # so we need to check if the record is persisted
+    if object.persisted?
+      data.slice(*policy.present_attributes)
+    else
+      data
+    end
+  end
+
+  private
+
+  def applicant_records
+    if policy.present_applicants?
+      object.users
+    else
+      if object.accepted_applicant?(current_user)
+        [current_user]
+      else
+        User.none
+      end
+    end
+  end
+
+  def policy
+    @_job_policy ||= JobPolicy.new(current_user, object)
+  end
 end
 
 # == Schema Information

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -22,24 +22,36 @@ RSpec.describe ApplicationPolicy do
 
   subject { ApplicationPolicy.new(nil, MockRecord.new(1)) }
 
-  it 'returns false for index' do
+  it 'returns false for #index?' do
     expect(subject.index?).to eq(false)
   end
 
-  it 'returns false for show' do
+  it 'returns false for #show?' do
     expect(subject.show?).to eq(false)
   end
 
-  it 'returns false for create' do
+  it 'returns false for #create?' do
     expect(subject.create?).to eq(false)
   end
 
-  it 'returns false for update' do
+  it 'returns false for #update?' do
     expect(subject.update?).to eq(false)
   end
 
-  it 'returns false for destroy' do
+  it 'returns false for #destroy?' do
     expect(subject.destroy?).to eq(false)
+  end
+
+  it 'returns false for #user?' do
+    expect(subject.send(:user?)).to eq(false)
+  end
+
+  it 'returns true for #no_user?' do
+    expect(subject.send(:no_user?)).to eq(true)
+  end
+
+  it 'returns false for #admin?' do
+    expect(subject.send(:admin?)).to eq(false)
   end
 
   describe ApplicationPolicy::Scope do

--- a/spec/policies/job_policy_spec.rb
+++ b/spec/policies/job_policy_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe JobPolicy do
       policy = JobPolicy.new(nil, persisted_job)
       expect(policy.permitted_attributes).to eq([])
     end
+
+    it 'returns false for #present_applicants?' do
+      expect(subject.present_applicants?).to eq(false)
+    end
+
+    it 'returns false for #present_self_applicant?' do
+      expect(subject.present_self_applicant?).to eq(false)
+    end
   end
 
   context 'with user' do
@@ -69,6 +77,14 @@ RSpec.describe JobPolicy do
       policy = JobPolicy.new(user, persisted_job)
       expect(policy.permitted_attributes).to eq([])
     end
+
+    it 'returns false for #present_applicants?' do
+      expect(subject.present_applicants?).to eq(false)
+    end
+
+    it 'returns false for #present_self_applicant?' do
+      expect(subject.present_self_applicant?).to eq(false)
+    end
   end
 
   context 'with accepted applicant user' do
@@ -88,6 +104,18 @@ RSpec.describe JobPolicy do
       job.accept_applicant!(user)
       expect(subject.permitted_attributes).to eq(accepted_applicant_params)
     end
+
+    it 'returns false for #present_applicants?' do
+      job.users = [user]
+      job.accept_applicant!(user)
+      expect(subject.present_applicants?).to eq(false)
+    end
+
+    it 'returns true for #present_self_applicant?' do
+      job.users = [user]
+      job.accept_applicant!(user)
+      expect(subject.present_self_applicant?).to eq(true)
+    end
   end
 
   context 'with owner user' do
@@ -105,6 +133,14 @@ RSpec.describe JobPolicy do
       policy = JobPolicy.new(nil, persisted_job)
       expect(policy.permitted_attributes).to eq([])
     end
+
+    it 'returns true for #present_applicants?' do
+      expect(subject.present_applicants?).to eq(true)
+    end
+
+    it 'returns false for #present_self_applicant?' do
+      expect(subject.present_self_applicant?).to eq(false)
+    end
   end
 
   context 'with admin user' do
@@ -119,6 +155,14 @@ RSpec.describe JobPolicy do
 
     it '#permitted_attributes is correct for non-persisted job' do
       expect(subject.permitted_attributes).to eq(admin_params)
+    end
+
+    it 'returns true for #present_applicants?' do
+      expect(subject.present_applicants?).to eq(true)
+    end
+
+    it 'returns false for #present_self_applicant?' do
+      expect(subject.present_self_applicant?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
* Only show applicants to Owner & Admin and allow a user to see if they themselves are an applicant
* Restrict what data is returned from the JobSerializer depending on a user

Closes #146

__TODO__

- [ ] Test `JobSerializer`
- [x] Test `JobPolicy`
- [ ] See if there is a cleaner way of having `Doxxer` call serializers with non-persisted objects, so that we don't need to check for `object.persisted?` everywhere..