### PR TITLE
Load Geocoder & Webmock in rails_helper spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ $ script/test spec/models/user_spec.rb:31
 $ COVERAGE=true script/test
 ```
 
-_Note_: Running the tests with `bundle exec rspec` will not work, please use `script/test` instead.
-
 ## Docs
 
 [Docs for the current version of the API](http://just-match-api.herokuapp.com/).

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,9 @@ require 'spec_helper'
 require 'rspec/rails'
 require 'shoulda/matchers'
 require 'pundit/rspec'
+require 'webmock/rspec'
+
+require 'spec_support/geocoder_support'
 
 # Checks for pending migration and applies them before tests are run.
 ActiveRecord::Migration.maintain_test_schema!
@@ -51,3 +54,7 @@ RSpec.configure do |config|
     end
   end
 end
+
+# Only allow the tests to connect to localhost and  allow codeclimate
+# codeclimate (for test coverage reporting)
+WebMock.disable_net_connect!(allow_localhost: true, allow: 'codeclimate.com')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,6 @@ elsif ENV.fetch('COVERAGE', false)
   SimpleCov.start 'rails'
 end
 
-require 'webmock/rspec'
-
-require 'spec_support/geocoder_support'
-
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -43,7 +39,3 @@ RSpec.configure do |config|
   # the `--only-failures` and `--next-failure` CLI options.
   config.example_status_persistence_file_path = 'spec/.rspec_examples.txt'
 end
-
-# Only allow the tests to connect to localhost and  allow codeclimate
-# codeclimate (for test coverage reporting)
-WebMock.disable_net_connect!(allow_localhost: true, allow: 'codeclimate.com')


### PR DESCRIPTION
Previously the Geocoder mock configuration was loaded from spec_helper.rb,
causing it to fail when executed with `bundle exec rspec` due to it being loaded
by Rails and not in "pure" Ruby.

Removed reference to this behaviour in README.md

Closes #197