### PR TITLE
Create FrIlans Finans company on company create

### DIFF
--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -3,5 +3,34 @@ module Admin
   class CompaniesController < Admin::ApplicationController
     # See https://administrate-docs.herokuapp.com/customizing_controller_actions
     # for more information
+
+    def create
+      company = Company.new(company_attributes)
+
+      if company.valid?
+        ff_company = FrilansFinansApi::Company.create(attributes: frilans_attributes)
+        company.frilans_finans_id = ff_company.resource.id
+        company.save!
+
+        render :show, locals: locals_for(:show, company)
+      else
+        render :edit, locals: locals_for(:form, company)
+      end
+    end
+
+    private
+
+    def company_attributes
+      params.require(:company).permit(:name, :cin)
+    end
+
+    def frilans_attributes
+      params.require(:company).permit(:email)
+    end
+
+    def locals_for(template, company)
+      klass = "Administrate::Page::#{template.capitalize}".constantize
+      { page: klass.new(CompanyDashboard.new, company) }
+    end
   end
 end

--- a/app/dashboards/company_dashboard.rb
+++ b/app/dashboards/company_dashboard.rb
@@ -14,6 +14,7 @@ class CompanyDashboard < Administrate::BaseDashboard
     frilans_finans_id: Field::Number,
     name: Field::String,
     cin: Field::String,
+    email: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -47,7 +48,8 @@ class CompanyDashboard < Administrate::BaseDashboard
     :users,
     :name,
     :frilans_finans_id,
-    :cin
+    :cin,
+    :email
   ].freeze
 
   # Overwrite this method to customize how skills are displayed

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -6,6 +6,9 @@ class Company < ApplicationRecord
   validates :name, length: { minimum: 2 }, allow_blank: false
   validates :cin, uniqueness: true, length: { is: 10 }, allow_blank: false
   validates :frilans_finans_id, uniqueness: true, allow_nil: true
+
+  # Virtual attributes for Frilans Finans
+  attr_accessor :email
 end
 
 # == Schema Information


### PR DESCRIPTION
In the admin interface create a Frilans Finans company using their API, when creating a Company.

* This __will__ currently __fail__ if creating more than one company from the admin interface, since `FrilansFinans::FixtureClient` is currently the default client.

Closes #302