### PR TITLE
Allow job owner to get user images

### DIFF
--- a/app/controllers/api/v1/jobs/job_users_controller.rb
+++ b/app/controllers/api/v1/jobs/job_users_controller.rb
@@ -29,7 +29,7 @@ module Api
           api_versions '1.0'
         end
 
-        ALLOWED_INCLUDES = %w(job user).freeze
+        ALLOWED_INCLUDES = %w(job user user.user_images).freeze
 
         api :GET, '/jobs/:job_id/users', 'Show job users'
         description 'Returns list of job users if the user is allowed.'

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class AdminMailer < ApplicationMailer
-  def invoice_missing_company_frilans_finans_id_email(user:, invoice:)
+  def invoice_missing_company_frilans_finans_id_email(user:, invoice:, job:)
     @invoice = invoice
-    @company = invoice.job.company
+    @company = job.company
     @company_name = @company.name
 
     subject = I18n.t('admin.mailer.invoice_missing_company_frilans_finans_id.subject')

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -3,6 +3,7 @@ class InvoiceMailer < ApplicationMailer
   def invoice_created_email(user:, job:, owner:)
     @user_name = user.name
     @owner_name = owner.name
+    @owner_email = owner.email
     @job_name = job.name
 
     subject = I18n.t('mailer.invoice_created.subject')

--- a/app/notifiers/invoice_missing_company_frilans_finans_id_notifier.rb
+++ b/app/notifiers/invoice_missing_company_frilans_finans_id_notifier.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 class InvoiceMissingCompanyFrilansFinansIdNotifier < BaseNotifier
-  def self.call(invoice:)
+  def self.call(invoice:, job:)
     User.admins.each do |user|
       next if ignored?(user)
 
+      mailer_args = { user: user, invoice: invoice, job: job }
       AdminMailer.
-        invoice_missing_company_frilans_finans_id_email(user: user, invoice: invoice).
+        invoice_missing_company_frilans_finans_id_email(**mailer_args).
         deliver_later
     end
   end

--- a/app/services/create_invoice_service.rb
+++ b/app/services/create_invoice_service.rb
@@ -32,12 +32,9 @@ class CreateInvoiceService
 
     invoice.save!
 
-    admin_notify_klass.call(invoice: invoice)
+    admin_notify_klass.call(invoice: invoice, job: job)
 
-    InvoiceCreatedNotifier.call(
-      job: job_user.job,
-      user: job_user.user
-    )
+    InvoiceCreatedNotifier.call(job: job, user: user)
 
     invoice
   end

--- a/app/views/admin_mailer/invoice_missing_company_frilans_finans_id_email.html.erb
+++ b/app/views/admin_mailer/invoice_missing_company_frilans_finans_id_email.html.erb
@@ -8,6 +8,6 @@
         'admin.mailer.invoice_missing_company_frilans_finans_id.notice',
         company_link: link_to(@company_name, admin_company_url(@company)),
         invoice_link: link_to(@invoice.name, admin_invoice_url(@invoice))
-      ) %>
+      ).html_safe %>
   </body>
 </html>

--- a/app/views/invoice_mailer/invoice_created_email.html.erb
+++ b/app/views/invoice_mailer/invoice_created_email.html.erb
@@ -7,7 +7,7 @@
     <h1><%= I18n.t('mailer.invoice_created.congrats_line', name: @user_name) %></h1>
     <h3><%= I18n.t('mailer.invoice_created.performed_line', name: @owner_name) %></h3>
     <p><%= I18n.t('mailer.invoice_created.job_line', name: @job_name) %></p>
-    <p><%= I18n.t('mailer.invoice_created.contact_line', email: @owner_email) %></p>
+    <p><%= I18n.t('mailer.invoice_created.contact_line', email: mail_to(@owner_email)).html_safe %></p>
 
     <p><%= I18n.t('mailer.signoff') %></p>
   </body>

--- a/app/views/user_mailer/applicant_accepted_email.html.erb
+++ b/app/views/user_mailer/applicant_accepted_email.html.erb
@@ -7,7 +7,7 @@
     <h1><%= I18n.t('mailer.applicant_accepted.congrats_line', name: @user_name) %></h1>
     <h3><%= I18n.t('mailer.applicant_accepted.accepted_line') %></h3>
     <p><%= I18n.t('mailer.applicant_accepted.job_line', name: @job_name) %></p>
-    <p><%= I18n.t('mailer.applicant_accepted.contact_line', email: @owner_email) %></p>
+    <p><%= I18n.t('mailer.applicant_accepted.contact_line', email: mail_to(@owner_email)).html_safe %></p>
 
     <p><%= I18n.t('mailer.signoff') %></p>
   </body>

--- a/app/views/user_mailer/applicant_accepted_email.text.erb
+++ b/app/views/user_mailer/applicant_accepted_email.text.erb
@@ -2,6 +2,6 @@
 
 <%= I18n.t('mailer.applicant_accepted.accepted_line') %>
 <%= I18n.t('mailer.applicant_accepted.job_line', name: @job_name) %>
-<%= I18n.t('mailer.applicant_accepted.contact_line', email: @owner_email) %>
+<%= I18n.t('mailer.applicant_accepted.contact_line', email: mail_to(@owner_email)).html_safe %>
 
 <%= I18n.t('mailer.signoff') %>

--- a/app/views/user_mailer/job_match_email.html.erb
+++ b/app/views/user_mailer/job_match_email.html.erb
@@ -7,7 +7,7 @@
     <h1><%= I18n.t('mailer.job_match.congrats_line', name: @user_name) %></h1>
     <h3><%= I18n.t('mailer.job_match.accepted_line') %></h3>
     <p><%= I18n.t('mailer.job_match.job_line', name: @job_name) %></p>
-    <p><%= I18n.t('mailer.job_match.contact_line', email: @owner_email) %></p>
+    <p><%= I18n.t('mailer.job_match.contact_line', email: mail_to(@owner_email)).html_safe %></p>
 
     <p><%= I18n.t('mailer.signoff') %></p>
   </body>

--- a/app/views/user_mailer/job_user_performed_email.html.erb
+++ b/app/views/user_mailer/job_user_performed_email.html.erb
@@ -7,7 +7,7 @@
     <h1><%= I18n.t('mailer.job_performed.congrats_line', name: @owner_name) %></h1>
     <h3><%= I18n.t('mailer.job_performed.performed_line', name: @user_name) %></h3>
     <p><%= I18n.t('mailer.job_performed.job_line', name: @job_name) %></p>
-    <p><%= I18n.t('mailer.job_performed.contact_line', email: @user_email) %></p>
+    <p><%= I18n.t('mailer.job_performed.contact_line', email: mail_to(@user_email)).html_safe %></p>
 
     <p><%= I18n.t('mailer.signoff') %></p>
   </body>

--- a/app/views/user_mailer/new_applicant_email.html.erb
+++ b/app/views/user_mailer/new_applicant_email.html.erb
@@ -7,7 +7,7 @@
     <h1><%= I18n.t('mailer.new_applicant.congrats_line', name: @owner_name) %></h1>
     <p><%= I18n.t('mailer.new_applicant.job_line', name: @job_name) %></p>
     <h3><%= I18n.t('mailer.new_applicant.applicant_line', name: @user_name) %></h3>
-    <p><%= I18n.t('mailer.new_applicant.contact_line', email: @user_email, phone: @user_phone) %></p>
+    <p><%= I18n.t('mailer.new_applicant.contact_line', email: mail_to(@user_email), phone: @user_phone).html_safe %></p>
 
     <p><%= I18n.t('mailer.signoff') %></p>
   </body>

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe AdminMailer, type: :mailer do
   let(:company) { mock_model(Company, name: 'ACME') }
   let(:user) { mock_model User, email: 'admin@example.com' }
   let(:job) { mock_model Job, company: company }
-  let(:invoice) { mock_model Invoice, job: job, name: 'invoice #1' }
+  let(:invoice) { mock_model Invoice, user: user, name: 'invoice #1' }
 
   describe '#invoice_missing_company_frilans_finans_id_email' do
     let(:mail) do
       described_class.invoice_missing_company_frilans_finans_id_email(
         invoice: invoice,
-        user: user
+        user: user,
+        job: job
       )
     end
 

--- a/spec/notifiers/invoice_missing_company_frilans_finans_id_notifier_spec.rb
+++ b/spec/notifiers/invoice_missing_company_frilans_finans_id_notifier_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe InvoiceMissingCompanyFrilansFinansIdNotifier, type: :mailer do
   let(:mailer) { Struct.new(:deliver_later).new(nil) }
   let(:invoice) { mock_model Invoice }
+  let(:job) { mock_model Job }
 
   it 'must work' do
     # Create an admin to send the email to
@@ -12,9 +13,9 @@ RSpec.describe InvoiceMissingCompanyFrilansFinansIdNotifier, type: :mailer do
     allow(AdminMailer).to receive(:invoice_missing_company_frilans_finans_id_email).
       and_return(mailer)
 
-    described_class.call(invoice: invoice)
+    described_class.call(invoice: invoice, job: job)
 
-    mailer_args = { user: user, invoice: invoice }
+    mailer_args = { user: user, invoice: invoice, job: job }
     expect(AdminMailer).to have_received(
       :invoice_missing_company_frilans_finans_id_email
     ).with(mailer_args)

--- a/spec/support/include_params_spec.rb
+++ b/spec/support/include_params_spec.rb
@@ -38,6 +38,21 @@ RSpec.describe IncludeParams do
       end
     end
 
+    describe 'nested include in param' do
+      let(:param) { described_class.new('users,users.images') }
+
+      it 'can return none' do
+        expect(param.permit([])).to eq([])
+        expect(param.permit('')).to eq([])
+        expect(param.permit('jobs')).to eq([])
+      end
+
+      it 'can return many' do
+        expect(param.permit(['users'])).to eq(['users'])
+        expect(param.permit('users', 'users.images')).to eq(['users', 'users.images'])
+      end
+    end
+
     describe 'nil param' do
       let(:nil_param) { described_class.new(nil) }
 


### PR DESCRIPTION
* Allows a job owner to include a job users, user images with:
`GET /jobs/:job_id/users/:job_user_id?include=user.user-images`

*  Missing frilans finans id for company email bugfix