### PR TITLE
Allow Job#filled filter for jobs endpoint

### DIFF
--- a/app/controllers/api/v1/jobs/job_users_controller.rb
+++ b/app/controllers/api/v1/jobs/job_users_controller.rb
@@ -109,7 +109,7 @@ module Api
             update_notifier_klass.call(job_user: @job_user, owner: @job.owner)
 
             on_event(:will_perform) do
-              @job.update!(filled: true)
+              @job.fill_position!
               # Frilans Finans wants invoices to be pre-reported
               FrilansFinansInvoice.create!(job_user: @job_user)
             end

--- a/app/controllers/api/v1/jobs/job_users_controller.rb
+++ b/app/controllers/api/v1/jobs/job_users_controller.rb
@@ -109,6 +109,7 @@ module Api
             update_notifier_klass.call(job_user: @job_user, owner: @job.owner)
 
             on_event(:will_perform) do
+              @job.update!(filled: true)
               # Frilans Finans wants invoices to be pre-reported
               FrilansFinansInvoice.create!(job_user: @job_user)
             end

--- a/app/controllers/index/jobs_index.rb
+++ b/app/controllers/index/jobs_index.rb
@@ -2,7 +2,7 @@
 module Index
   class JobsIndex < BaseIndex
     TRANSFORMABLE_FILTERS = TRANSFORMABLE_FILTERS.merge(job_date: :date_range).freeze
-    ALLOWED_FILTERS = %i(id hours created_at job_date verified).freeze
+    ALLOWED_FILTERS = %i(id hours created_at job_date verified filled).freeze
     SORTABLE_FIELDS = %i(hours job_date name verified created_at updated_at).freeze
 
     def jobs(scope = Job)

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -78,6 +78,14 @@ class Job < ApplicationRecord
       where('jobs.owner_user_id = :user OR job_users.user_id = :user', user: user)
   end
 
+  def fill_position
+    update(filled: true)
+  end
+
+  def fill_position!
+    update!(filled: true)
+  end
+
   def locked_for_changes?
     applicant = applicants.find_by(accepted: true)
     return false unless applicant

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -47,7 +47,10 @@ class Job < ApplicationRecord
   belongs_to :owner, class_name: 'User', foreign_key: 'owner_user_id'
 
   scope :visible, -> { where(hidden: false) }
+  scope :cancelled, -> { where(cancelled: true) }
   scope :uncancelled, -> { where(cancelled: false) }
+  scope :filled, -> { where(filled: true) }
+  scope :unfilled, -> { where(filled: false) }
 
   # This will return an Array and not an ActiveRecord::Relation
   def self.non_hired
@@ -215,6 +218,7 @@ end
 #  verified      :boolean          default(FALSE)
 #  job_end_date  :datetime
 #  cancelled     :boolean          default(FALSE)
+#  filled        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -8,17 +8,18 @@ class JobPolicy < ApplicationPolicy
 
   FULL_ATTRIBUTES = [
     :id, :description, :job_date, :hours, :name, :created_at, :updated_at, :latitude,
-    :longitude, :street, :zip, :zip_latitude, :zip_longitude, :verified, :job_end_date
+    :longitude, :street, :zip, :zip_latitude, :zip_longitude, :verified, :job_end_date,
+    :filled
   ].freeze
 
   ATTRIBUTES = [
     :id, :description, :job_date, :hours, :name, :created_at, :updated_at, :zip,
-    :zip_latitude, :zip_longitude, :verified, :job_end_date
+    :zip_latitude, :zip_longitude, :verified, :job_end_date, :filled
   ].freeze
 
   OWNER_ATTRIBUTES = [
     :description, :job_date, :street, :zip, :name, :hours, :job_end_date, :cancelled,
-    :language_id, :category_id, :hourly_pay_id, skill_ids: []
+    :filled, :language_id, :category_id, :hourly_pay_id, skill_ids: []
   ].freeze
 
   def index?

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -62,6 +62,7 @@ end
 #  verified      :boolean          default(FALSE)
 #  job_end_date  :datetime
 #  cancelled     :boolean          default(FALSE)
+#  filled        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/db/migrate/20160604144410_add_filled_to_jobs.rb
+++ b/db/migrate/20160604144410_add_filled_to_jobs.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddFilledToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :filled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160523173633) do
+ActiveRecord::Schema.define(version: 20160604144410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -241,6 +241,7 @@ ActiveRecord::Schema.define(version: 20160523173633) do
     t.boolean  "verified",      default: false
     t.datetime "job_end_date"
     t.boolean  "cancelled",     default: false
+    t.boolean  "filled",        default: false
   end
 
   add_index "jobs", ["category_id"], name: "index_jobs_on_category_id", using: :btree

--- a/examples/responses/chat.json
+++ b/examples/responses/chat.json
@@ -15,6 +15,11 @@
         "data": [
 
         ]
+      },
+      "user-images": {
+        "data": [
+
+        ]
       }
     }
   }

--- a/examples/responses/chats.json
+++ b/examples/responses/chats.json
@@ -16,6 +16,11 @@
           "data": [
 
           ]
+        },
+        "user-images": {
+          "data": [
+
+          ]
         }
       }
     }

--- a/examples/responses/job.json
+++ b/examples/responses/job.json
@@ -16,7 +16,8 @@
       "zip-latitude": 59.7117339,
       "zip-longitude": 18.4256286,
       "verified": false,
-      "job-end-date": "2016-02-20 01:01:01 +0100"
+      "job-end-date": "2016-02-20 01:01:01 +0100",
+      "filled": false
     },
     "relationships": {
       "job-users": {

--- a/examples/responses/jobs.json
+++ b/examples/responses/jobs.json
@@ -14,7 +14,8 @@
         "zip-latitude": 59.7117339,
         "zip-longitude": 18.4256286,
         "verified": false,
-        "job-end-date": "2016-02-20 01:01:01 +0100"
+        "job-end-date": "2016-02-20 01:01:01 +0100",
+        "filled": false
       },
       "relationships": {
         "job-users": {

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -315,6 +315,7 @@ end
 #  verified      :boolean          default(FALSE)
 #  job_end_date  :datetime
 #  cancelled     :boolean          default(FALSE)
+#  filled        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/factories/job_factory.rb
+++ b/spec/factories/job_factory.rb
@@ -106,6 +106,7 @@ end
 #  verified      :boolean          default(FALSE)
 #  job_end_date  :datetime
 #  cancelled     :boolean          default(FALSE)
+#  filled        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe Job, type: :model do
     end
   end
 
+  describe '#fill_position' do
+    it 'sets filled to true' do
+      job = FactoryGirl.build(:job, filled: false)
+      job.fill_position
+      expect(job.filled).to eq(true)
+    end
+  end
+
+  describe '#fill_position!' do
+    it 'sets filled to true' do
+      job = FactoryGirl.build(:job, filled: false)
+      job.fill_position!
+      expect(job.filled).to eq(true)
+    end
+  end
+
   describe '#amount' do
     it 'can return the total amount that a user is to be payed' do
       hourly_pay = FactoryGirl.build(:hourly_pay, rate: 100)

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -386,6 +386,7 @@ end
 #  verified      :boolean          default(FALSE)
 #  job_end_date  :datetime
 #  cancelled     :boolean          default(FALSE)
+#  filled        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/policies/job_policy_spec.rb
+++ b/spec/policies/job_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe JobPolicy do
   let(:owner_params) do
     [
       :description, :job_date, :street, :zip, :name, :hours, :job_end_date,
-      :cancelled, :language_id, :category_id, :hourly_pay_id, { skill_ids: [] }
+      :cancelled, :filled, :language_id, :category_id, :hourly_pay_id, { skill_ids: [] }
     ]
   end
   let(:admin_params) { owner_params }

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -35,6 +35,7 @@ end
 #  verified      :boolean          default(FALSE)
 #  job_end_date  :datetime
 #  cancelled     :boolean          default(FALSE)
+#  filled        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/routing/jobs_routing_spec.rb
+++ b/spec/routing/jobs_routing_spec.rb
@@ -57,6 +57,7 @@ end
 #  verified      :boolean          default(FALSE)
 #  job_end_date  :datetime
 #  cancelled     :boolean          default(FALSE)
+#  filled        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/serializers/job_serializer_spec.rb
+++ b/spec/serializers/job_serializer_spec.rb
@@ -55,6 +55,7 @@ end
 #  verified      :boolean          default(FALSE)
 #  job_end_date  :datetime
 #  cancelled     :boolean          default(FALSE)
+#  filled        :boolean          default(FALSE)
 #
 # Indexes
 #


### PR DESCRIPTION
Add filter support for job filled attribute: `/jobs?filter[filled]=false` fill only return jobs that haven't been filled yet.

The difference between #383 and this PR is that the API will still return filled positions, but the front-ends can decide to exclude them.