### PR TITLE
Add support for sending magic login links (sms/email)

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -24,4 +24,11 @@ class UserMailer < ApplicationMailer
     subject = I18n.t('mailer.changed_password.subject')
     mail(to: user.email, subject: subject)
   end
+
+  def magic_login_link_email(user:)
+    @magic_login_url = FrontendRouter.draw(:magic_login_link, token: user.one_time_token)
+
+    subject = I18n.t('mailer.magic_login_link.subject')
+    mail(to: user.email, subject: subject)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,14 +89,12 @@ class User < ApplicationRecord
   end
 
   def self.find_by_credentials(email_or_phone:, password:)
-    return if email_or_phone.blank?
-
-    user = find_by(email: email_or_phone)
-    user ||= find_by_phone(email_or_phone, normalize: true)
+    user = find_by_email_or_phone(email_or_phone)
 
     return if user.nil?
+    return unless correct_password?(user, password)
 
-    user if correct_password?(user, password)
+    user
   end
 
   def self.find_by_phone(phone, normalize: false)
@@ -107,6 +105,12 @@ class User < ApplicationRecord
     end
 
     find_by(phone: phone_number)
+  end
+
+  def self.find_by_email_or_phone(email_or_phone)
+    return if email_or_phone.blank?
+
+    find_by(email: email_or_phone) || find_by_phone(email_or_phone, normalize: true)
   end
 
   def self.correct_password?(user, password)

--- a/app/notifiers/magic_login_link_notifier.rb
+++ b/app/notifiers/magic_login_link_notifier.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MagicLoginLinkNotifier < BaseNotifier
+  def self.call(user:)
+    UserTexter.
+      magic_login_link_text(user: user).
+      deliver_later
+
+    UserMailer.
+      magic_login_link_email(user: user).
+      deliver_later
+  end
+end

--- a/app/texters/user_texter.rb
+++ b/app/texters/user_texter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class UserTexter < ApplicationTexter
+  def self.magic_login_link_text(user:)
+    @magic_login_url = FrontendRouter.draw(:magic_login_link, token: user.one_time_token)
+
+    text(to: user.phone, template: 'user_texter/magic_login_link_text')
+  end
+end

--- a/app/views/user_mailer/magic_login_link_email.html.erb
+++ b/app/views/user_mailer/magic_login_link_email.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>
+      <%= I18n.t(
+        'mailer.magic_login_link.login_line',
+        url: "<a href=\"#{@magic_login_url}\">#{@magic_login_url}</a>"
+      ).html_safe %>
+    </p>
+
+    <p><%= I18n.t('mailer.signoff') %></p>
+  </body>
+</html>

--- a/app/views/user_mailer/magic_login_link_email.text.erb
+++ b/app/views/user_mailer/magic_login_link_email.text.erb
@@ -1,0 +1,1 @@
+<%= I18n.t('mailer.magic_login_link.login_line', url: @magic_login_url) %>

--- a/app/views/user_texter/magic_login_link_text.text.erb
+++ b/app/views/user_texter/magic_login_link_text.text.erb
@@ -1,0 +1,1 @@
+<%= I18n.t('texter.magic_login_link.login_line', url: @magic_login_url) %>

--- a/config/frontend_routes.yml
+++ b/config/frontend_routes.yml
@@ -2,6 +2,7 @@ routes:
   base_url: 'https://app.justarrived.se/#/'
   reset_password: 'reset_password/%{token}'
   login: 'user/signin'
+  magic_login_link: 'user/magic-login/%{token}'
   job: 'jobs/%{id}'
   jobs: 'jobs'
   faqs: 'faq'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,9 @@ en:
       job_line: 'The job you performed was: ''%{name}''.'
       performed_line: "%{name} has verified that you've performed the job."
       subject: Congrats! A job you performed has been accepted.
+    magic_login_link:
+      subject: Magic sign-in link
+      login_line: To login to JustArrived use the link %{url}
     new_applicant:
       applicant_line: The applicant is '%{name}' and lives close to where the assignment will be carried out.
       congrats_line: Congratulations %{name}!
@@ -125,3 +128,6 @@ en:
     user_job_match: New job match
     job_cancelled: Job cancelled
     new_chat_message: New chat message
+  texter:
+    magic_login_link:
+      login_line: JustArrived magic login link %{url}

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -101,6 +101,9 @@ sv:
       contact_line: Om du har några frågor, kan du kontakt dem på %{email} och %{phone}.
       job_line: Du har en ny ansökning till ditt jobb '%{name}'.
       subject: Grattis! Du har en fått en ny ansökan.
+    magic_login_link:
+      subject: Magisk inloggningslänk
+      login_line: För att logga in på JustArrived använd länken %{url}
     new_chat_message:
       view_chat_line: Du kan också läsa meddelandet här %{url}, där kan du också få meddelandet översatt.
       received_from_line: Du har fått ett nytt meddelande från %{name}.
@@ -125,3 +128,6 @@ sv:
     user_job_match: Ny jobb matchning
     job_cancelled: Jobb avbrutet
     new_chat_message: Nytt chatt meddelande
+  texter:
+    magic_login_link:
+      login_line: JustArrived magisk inloggningslänk %{url}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 require 'sidekiq/web'
 
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-  User.find_by_credentials(email: username, password: password)
+  User.find_by_credentials(email_or_phone: username, password: password)
 end
 
 Rails.application.routes.draw do
@@ -74,7 +74,11 @@ Rails.application.routes.draw do
         end
 
         collection do
-          resources :user_sessions, module: :users, path: :sessions, only: [:create, :destroy]
+          resources :user_sessions, module: :users, path: :sessions, only: [:create, :destroy] do
+            collection do
+              post :magic_link, path: 'magic-link'
+            end
+          end
           resources :reset_password, path: 'reset-password', module: :users, only: [:create]
           resources :change_password, path: 'change-password', module: :users, only: [:create]
           resources :user_images, module: :users, path: :images, only: [:create]

--- a/spec/initializers/frontend_routes_spec.rb
+++ b/spec/initializers/frontend_routes_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe FrontendRoutesReader do
     expect(result).to eq(expected)
   end
 
+  it 'returns magic login route' do
+    token = 'watman'
+    result = subject.draw(:magic_login_link, token: token)
+    expected = "#{base_url}user/magic-login/#{token}"
+    expect(result).to eq(expected)
+  end
+
   it 'returns faqs route' do
     result = subject.draw(:faqs)
     expected = "#{base_url}faq"

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -14,4 +14,10 @@ class UserMailerPreview < ActionMailer::Preview
   def changed_password_email
     UserMailer.changed_password_email(user: User.first)
   end
+
+  def magic_login_link_email
+    user = User.first
+    user.generate_one_time_token
+    UserMailer.magic_login_link_email(user: user)
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -96,4 +96,23 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail).to match_email_body(user.first_name)
     end
   end
+
+  describe '#magic_login_link_email' do
+    let(:user) { FactoryGirl.build(:user_with_one_time_token) }
+    let(:mail) { described_class.magic_login_link_email(user: user) }
+
+    it 'has both text and html part' do
+      expect(mail).to be_multipart_email(true)
+    end
+
+    it 'renders the subject' do
+      subject = I18n.t('mailer.magic_login_link.subject')
+      expect(mail.subject).to eql(subject)
+    end
+
+    it 'includes users reset password url' do
+      url = FrontendRouter.draw(:magic_login_link, token: user.one_time_token)
+      expect(mail).to match_email_body(url)
+    end
+  end
 end

--- a/spec/notifiers/magic_login_link_notifier_spec.rb
+++ b/spec/notifiers/magic_login_link_notifier_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe MagicLoginLinkNotifier, type: :mailer do
+  before(:each) do
+    mock = Struct.new(:deliver_later).new(nil)
+    allow(UserMailer).to receive(:magic_login_link_email).and_return(mock)
+    allow(UserTexter).to receive(:magic_login_link_text).and_return(mock)
+  end
+  let(:user) { nil }
+
+  it 'calls user mailer' do
+    described_class.call(user: user)
+    expect(UserMailer).to have_received(:magic_login_link_email).with(user: user).once
+  end
+
+  it 'calls job texter' do
+    described_class.call(user: user)
+    expect(UserTexter).to have_received(:magic_login_link_text).with(user: user).once
+  end
+end

--- a/spec/routing/user_sessions_routing_spec.rb
+++ b/spec/routing/user_sessions_routing_spec.rb
@@ -9,13 +9,17 @@ RSpec.describe Api::V1::UsersController, type: :routing do
       route_path = 'api/v1/users/user_sessions#create'
       expect(post: path).to route_to(route_path)
     end
-  end
 
-  describe 'routing' do
     it 'routes delete to #destroy' do
       path = '/api/v1/users/sessions/_invalid_auth_token'
       route_path = 'api/v1/users/user_sessions#destroy'
       expect(delete: path).to route_to(route_path, id: '_invalid_auth_token')
+    end
+
+    it 'routes post to #magic_link' do
+      path = '/api/v1/users/sessions/magic-link'
+      route_path = 'api/v1/users/user_sessions#magic_link'
+      expect(post: path).to route_to(route_path)
     end
   end
 end

--- a/spec/texters/user_texter_spec.rb
+++ b/spec/texters/user_texter_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe UserTexter do
+  let(:one_time_token) { 'watwoman' }
+  let(:user) { FactoryGirl.build(:user, one_time_token: one_time_token) }
+
+  describe '#applicant_accepted_text' do
+    let!(:text) do
+      described_class.magic_login_link_text(user: user).deliver_now
+    end
+    let(:last_message_body) { FakeSMS.messages.last.body }
+
+    it 'renders the frontend URL for the magic login link' do
+      url = FrontendRouter.draw(:magic_login_link, token: one_time_token)
+      expect(last_message_body).to match(url)
+    end
+  end
+end


### PR DESCRIPTION
* Add endpoint `/users/sessions/magic-link`
* Add notifier for sending magic links
  - Add `UserTexter#magic_login_link_text`
  - Add `UserMailer#magic_login_link_email`
* Extract method in `User` model
* Add mailer/texter copy

Closes #429 

---

⚠️ Assumes that the frontend has a route `/user/magic-login/:token`