### PR TITLE
Hotfix: Don't allow expired tokens to be found from the User model

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -77,7 +77,6 @@ module Api
               #{Doxxer.curl_for(name: 'users', id: 1, auth: true, join_with: " \\
                      ")}
         DOCDESCRIPTION
-        # rubocop:enable Metrics/LineLength
         api_base_url '/api/v1'
       end
 

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -12,6 +12,7 @@ class Token < ApplicationRecord
   validates :expires_at, presence: true
 
   scope :expired, -> { where('expires_at < ?', Time.zone.now) }
+  scope :not_expired, -> { where('expires_at > ?', Time.zone.now) }
 
   def regenerate_token
     self.token = SecureGenerator.token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,11 +119,11 @@ class User < ApplicationRecord
   end
 
   def self.find_token(auth_token)
-    Token.find_by(token: auth_token)
+    Token.not_expired.find_by(token: auth_token)
   end
 
   def self.find_token!(auth_token)
-    Token.find_by!(token: auth_token)
+    Token.not_expired.find_by!(token: auth_token)
   end
 
   def self.find_by_auth_token(auth_token)

--- a/spec/factories/token_factory.rb
+++ b/spec/factories/token_factory.rb
@@ -3,6 +3,10 @@ FactoryGirl.define do
   factory :token do
     association :user
     token SecureGenerator.token
+
+    factory :expired_token do
+      expires_at Date.new(2016, 1, 1)
+    end
   end
 end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -488,6 +488,24 @@ RSpec.describe User, type: :model do
       expect(message || []).not_to include(error_message)
     end
   end
+
+  describe '#find_token' do
+    context 'valid token' do
+      it 'returns token' do
+        token = FactoryGirl.create(:token)
+
+        expect(User.find_token(token.token)).to eq(token)
+      end
+    end
+
+    context 'valid token' do
+      it 'returns nil' do
+        token = FactoryGirl.create(:expired_token)
+
+        expect(User.find_token(token.token)).to be_nil
+      end
+    end
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
😳 I've totally missed to only find tokens that aren't expired. Causing tokens to be valid forever.

This fixes that and only finds tokens that haven't expired.