### PR TITLE
Don't send unneeded notifications to admins in FF invoice create service

### DIFF
--- a/app/services/create_frilans_finans_invoice_service.rb
+++ b/app/services/create_frilans_finans_invoice_service.rb
@@ -11,8 +11,9 @@ class CreateFrilansFinansInvoiceService
     end
 
     ff_invoice_remote = frilans_finans_invoice(user: user, job: job)
-    frilans_finans_id = ff_invoice_remote.resource.id
+    return ff_invoice if ff_invoice_remote.error_status?
 
+    frilans_finans_id = ff_invoice_remote.resource.id
     ff_invoice.frilans_finans_id = frilans_finans_id
 
     if frilans_finans_id.nil?

--- a/app/support/frilans_finans_event_logger.rb
+++ b/app/support/frilans_finans_event_logger.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 class FrilansFinansEventLogger
   def request_event(params:, status:, verb:, uri:, body:)
     FrilansFinansApiLog.create!(

--- a/lib/frilans_finans_api/lib/frilans_finans_api/document.rb
+++ b/lib/frilans_finans_api/lib/frilans_finans_api/document.rb
@@ -63,5 +63,10 @@ module FrilansFinansApi
     def count
       json.dig('meta', 'pagination', 'count')
     end
+
+    def error_status?
+      # Consider both 300, 400 and 500-statuses as errors
+      status >= 300
+    end
   end
 end

--- a/lib/frilans_finans_api/spec/document_spec.rb
+++ b/lib/frilans_finans_api/spec/document_spec.rb
@@ -2,8 +2,8 @@
 require 'spec_helper'
 
 RSpec.describe FrilansFinansApi::Document do
-  context 'status' do
-    let(:response) { mock_httparty_response(code: 200, body: '{}') }
+  describe 'status' do
+    let(:response) { mock_httparty_response(code: 200) }
 
     subject do
       described_class.new(response)
@@ -14,7 +14,29 @@ RSpec.describe FrilansFinansApi::Document do
     end
   end
 
-  context 'uri' do
+  describe 'error_status?' do
+    let(:response) { mock_httparty_response(code: 422) }
+
+    subject do
+      described_class.new(response)
+    end
+
+    context 'response is error status' do
+      it 'returns true' do
+        expect(subject.error_status?).to eq(true)
+      end
+    end
+
+    context 'response is *not* error status' do
+      let(:response) { mock_httparty_response(code: 200) }
+
+      it 'returns true' do
+        expect(subject.error_status?).to eq(false)
+      end
+    end
+  end
+
+  describe 'uri' do
     let(:uri) { 'http://example.com' }
     let(:response) { mock_httparty_response(uri: uri) }
 

--- a/spec/services/create_frilans_finans_invoice_service_spec.rb
+++ b/spec/services/create_frilans_finans_invoice_service_spec.rb
@@ -92,12 +92,6 @@ RSpec.describe CreateFrilansFinansInvoiceService do
       end
     end
 
-    it 'does persist invoice' do
-      isolate_frilans_finans_client(FrilansFinansApi::NilClient) do
-        expect(subject.persisted?).to eq(true)
-      end
-    end
-
     it 'does call Frilans Finans API' do
       isolate_frilans_finans_client(FrilansFinansApi::NilClient) do
         allow(frilans_api_klass).to receive(:create).and_return(ff_nil_document_mock)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,7 @@ FrilansFinansApi.client_klass = FrilansFinansApi::FixtureClient
 FrilansFinansApi.base_uri = 'https://example.com'
 FrilansFinansApi.client_id = '123456'
 FrilansFinansApi.client_secret = 'notsosecret'
+FrilansFinansApi.event_logger = FrilansFinansApi::NilEventLogger.new
 
 # Only allow the tests to connect to localhost and  allow codeclimate
 # codeclimate (for test coverage reporting)


### PR DESCRIPTION
* Add `Document#error_status?` to FrilansFinansApi lib
* Don't continue in invoice service in Frilans Finans returns an HTTP error status