### PR TITLE
Add support for JSONAPI fields query paramter

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -148,6 +148,7 @@ module Api
         serialized_model = JsonApiSerializer.serialize(
           model_or_model_array,
           included: included_resources,
+          fields: fields_params.to_h,
           current_user: current_user,
           meta: meta,
           request: request

--- a/lib/json_api_helpers/lib/json_api_helpers/params/fields.rb
+++ b/lib/json_api_helpers/lib/json_api_helpers/params/fields.rb
@@ -5,31 +5,16 @@ module JsonApiHelpers
       attr_reader :fields_params
 
       def initialize(fields_params)
-        @fields_params = fields_params || {}
-      end
-
-      def permit(resources_hash)
-        permitted = {}
-        resources_hash.map do |resource_symbol, whitelisted_fields|
-          requested_fields = fields_params[resource_symbol]
-          whitelist = whitelisted_fields.map(&:to_s)
-
-          permitted[resource_symbol] = merge_fields(requested_fields, whitelist)
-        end
-        permitted
-      end
-
-      private
-
-      def merge_fields(requested_fields, whitelisted_fields)
-        if requested_fields
-          fields = requested_fields.split(',').map do |field|
-            StringSupport.underscore(field)
+        @fields_params = {}
+        (fields_params || {}).each do |model_name, value|
+          @fields_params[model_name] = value.split(',').map do |name|
+            StringSupport.underscore(name.strip)
           end
-          fields & whitelisted_fields
-        else
-          whitelisted_fields
         end
+      end
+
+      def to_h
+        fields_params
       end
     end
   end

--- a/lib/json_api_helpers/lib/json_api_helpers/serializers/model.rb
+++ b/lib/json_api_helpers/lib/json_api_helpers/serializers/model.rb
@@ -4,7 +4,7 @@ require 'json_api_helpers/action_dispatch_request_wrapper'
 module JsonApiHelpers
   module Serializers
     class Model
-      attr_reader :serializer, :included, :current_user, :model_scope, :meta, :request
+      attr_reader :serializer, :included, :fields, :current_user, :model_scope, :meta, :request # rubocop:disable Metrics/LineLength
 
       def self.serialize(*args)
         new(*args).serialize
@@ -12,9 +12,10 @@ module JsonApiHelpers
 
       # private
 
-      def initialize(model_scope, included: [], current_user: nil, meta: {}, request: nil)
+      def initialize(model_scope, included: [], fields: {}, current_user: nil, meta: {}, request: nil) # rubocop:disable Metrics/LineLength
         @model_scope = model_scope
         @included = included
+        @fields = fields
         @meta = meta
         @current_user = current_user
         # NOTE: ActiveModel::Serializer#serializer_for is from active_model_serializers
@@ -37,6 +38,7 @@ module JsonApiHelpers
         ActiveModelSerializers::Adapter.create(
           serializer_instance,
           include: included,
+          fields: fields,
           meta: meta,
           serialization_context: request
         )

--- a/lib/json_api_helpers/spec/json_api_helpers/params/fields_spec.rb
+++ b/lib/json_api_helpers/spec/json_api_helpers/params/fields_spec.rb
@@ -9,6 +9,24 @@ RSpec.describe JsonApiHelpers::Params::Fields do
     }
   end
 
+  describe '#to_h' do
+    it 'converts fields params to hash' do
+      fields_params = {
+        jobs: 'name,hours,job-date',
+        users: 'name'
+      }
+      expected = {
+        jobs: %w(name hours job_date),
+        users: %w(name)
+      }
+      expect(described_class.new(fields_params).to_h).to eq(expected)
+    end
+
+    it 'returns empty hash when fields params empty' do
+      expect(described_class.new({}).to_h).to eq({})
+    end
+  end
+
   describe '#permit' do
     context 'with fields params nil' do
       subject { described_class.new(nil) }

--- a/lib/json_api_helpers/spec/json_api_helpers/params/fields_spec.rb
+++ b/lib/json_api_helpers/spec/json_api_helpers/params/fields_spec.rb
@@ -26,38 +26,4 @@ RSpec.describe JsonApiHelpers::Params::Fields do
       expect(described_class.new({}).to_h).to eq({})
     end
   end
-
-  describe '#permit' do
-    context 'with fields params nil' do
-      subject { described_class.new(nil) }
-
-      it 'returns whitelist when nothing permitted' do
-        expect(subject.permit(owner: [:email])).to eq(owner: ['email'])
-      end
-    end
-
-    context 'with fields params' do
-      subject { described_class.new(params) }
-
-      let(:owner_params) { { owner: ['email'] } }
-      let(:job_params) { { jobs: %w(full_name email) } }
-
-      it 'returns empty when nothing permitted' do
-        expect(subject.permit({})).to eq({})
-      end
-
-      it 'only returns allowed field' do
-        expect(subject.permit(owner_params)).to eq(owner_params)
-      end
-
-      it 'only returns allowed fields' do
-        expect(subject.permit(job_params)).to eq(job_params)
-      end
-
-      it 'only returns allowed fields' do
-        both_params = job_params.merge(owner_params)
-        expect(subject.permit(both_params)).to eq(both_params)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Closes #557 

This allows the client to ask for the minimum amount of information required, therefore speeding up the request.

For example:

Fetch job `1` include its owner and limit the job and users fields returned

```
GET /api/v1/jobs/1/?include=owner&fields[jobs]=name,hours,job_date,job_end_date&fields[users]=first-name
```

Returns

```JSON
{
  "data": {
    "id": "1",
    "type": "jobs",
    "attributes": {
      "description": "Plaid keytar loko butcher. Bespoke iphone bicycle rights distillery pitchfork pork belly etsy.",
      "job-date": "2016-05-14T08:32:22.640+02:00",
      "hours": 35,
      "name": "Mrs. Greg Maggio",
      "job-end-date": "2016-05-19T08:32:22.641+02:00"
    },
    "links": {
      "self": "https://api.justarrived.se/api/v1/jobs/1"
    }
  },
  "included": [
    {
      "id": "52",
      "type": "users",
      "attributes": {
        "first-name": "Caesar"
      },
      "links": {
        "self": "https://api.justarrived.se/api/v1/users/52"
      }
    }
  ]
}
```