### PR TITLE
Converty #try to &. (a.k.a lonely operator)

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -88,7 +88,7 @@ module Api
       example Doxxer.read_example(User, method: :create)
       def create
         @user = User.new(user_params)
-        @user.email = @user.email.try(:strip)
+        @user.email = @user.email&.strip
 
         authorize(@user)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,7 +132,7 @@ class User < ApplicationRecord
   end
 
   def self.find_by_auth_token(auth_token)
-    find_token(auth_token).try(:user)
+    find_token(auth_token)&.user
   end
 
   def self.find_by_auth_token!(auth_token)
@@ -212,7 +212,7 @@ class User < ApplicationRecord
   end
 
   def auth_token
-    auth_tokens.last.try(:token)
+    auth_tokens.last&.token
   end
 
   def set_normalized_phone


### PR DESCRIPTION
Converts the remaining `#try` calls to `&.`.

__Example__:

```ruby
user.try(:email)
# becomes
user&.email
```