### PR TITLE
Add ability to define key-transform using X-API-KEY-TRANSFORM

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -147,6 +147,7 @@ module Api
 
         serialized_model = JsonApiSerializer.serialize(
           model_or_model_array,
+          key_transform: key_transform_header,
           included: included_resources,
           fields: fields_params.to_h,
           current_user: current_user,
@@ -226,6 +227,14 @@ module Api
 
       def api_promo_code_header
         request.headers['X-API-PROMO-CODE']
+      end
+
+      def key_transform_header
+        case request.headers['X-API-KEY-TRANSFORM']
+        when 'underscore' then :underscore
+        else
+          'dash'
+        end
       end
 
       private

--- a/lib/json_api_helpers/lib/json_api_helpers/serializers/model.rb
+++ b/lib/json_api_helpers/lib/json_api_helpers/serializers/model.rb
@@ -4,7 +4,7 @@ require 'json_api_helpers/action_dispatch_request_wrapper'
 module JsonApiHelpers
   module Serializers
     class Model
-      attr_reader :serializer, :included, :fields, :current_user, :model_scope, :meta, :request # rubocop:disable Metrics/LineLength
+      attr_reader :serializer, :included, :fields, :current_user, :model_scope, :meta, :request, :key_transform # rubocop:disable Metrics/LineLength
 
       def self.serialize(*args)
         new(*args).serialize
@@ -12,12 +12,13 @@ module JsonApiHelpers
 
       # private
 
-      def initialize(model_scope, included: [], fields: {}, current_user: nil, meta: {}, request: nil) # rubocop:disable Metrics/LineLength
+      def initialize(model_scope, key_transform: :dash, included: [], fields: {}, current_user: nil, meta: {}, request: nil) # rubocop:disable Metrics/LineLength
         @model_scope = model_scope
         @included = included
         @fields = fields
         @meta = meta
         @current_user = current_user
+        @key_transform = key_transform
         # NOTE: ActiveModel::Serializer#serializer_for is from active_model_serializers
         @serializer = ActiveModel::Serializer.serializer_for(model_scope)
         @request = ActionDispatchRequestWrapper.new(request)
@@ -37,6 +38,7 @@ module JsonApiHelpers
         # NOTE: ActiveModelSerializers::Adapter#create is from active_model_serializers
         ActiveModelSerializers::Adapter.create(
           serializer_instance,
+          key_transform: key_transform,
           include: included,
           fields: fields,
           meta: meta,

--- a/spec/requests/base_controller_spec.rb
+++ b/spec/requests/base_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'BaseController', type: :request do
+  before(:each) do
+    FactoryGirl.create(:job, short_description: 'shortdescription')
+  end
+
+  describe 'key transform header' do
+    context 'with X-API-KEY-TRANSFORM underscore' do
+      it 'returns all keys in underscore format' do
+        get api_v1_jobs_path, headers: { 'X-API-KEY-TRANSFORM' => 'underscore' }
+
+        parsed_body = JSON.parse(response.body)
+        first_data = parsed_body['data'].first
+        short_description = first_data.dig('attributes', 'short-description')
+        expect(short_description).to eq('shortdescription')
+      end
+    end
+
+    context 'with X-API-KEY-TRANSFORM dash' do
+      it 'returns all keys in dashed/kebab-case format' do
+        get api_v1_jobs_path, headers: { 'X-API-KEY-TRANSFORM' => 'dash' }
+
+        parsed_body = JSON.parse(response.body)
+        first_data = parsed_body['data'].first
+        short_description = first_data.dig('attributes', 'short-description')
+
+        expect(short_description).to eq('shortdescription')
+      end
+
+      it 'returns all keys in dashed/kebab-case format by default' do
+        get api_v1_jobs_path
+
+        parsed_body = JSON.parse(response.body)
+        first_data = parsed_body['data'].first
+        short_description = first_data.dig('attributes', 'short-description')
+
+        expect(short_description).to eq('shortdescription')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support for defining: `X-API-KEY-TRANSFORM`, `dash`/kebab-case is the default, since we need to keep backward compatibility (will however be deprecated after the old frontend has been 🔪) and `underscore` will be the only available option. 

__Example__:

```
curl -H "X-API-KEY-TRANSFORM: dash" -H "http://localhost:3000/api/v1/jobs?"
```
