### PR TITLE
Return custom error for expired tokens & Refactor #current_user method

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -90,6 +90,9 @@ module Api
 
       # JSONAPI error codes
       TOKEN_EXPIRED_CODE = :token_expired
+      LOGIN_REQUIRED_CODE = :login_required
+      INVALID_CREDENTIALS_CODE = :invalid_credentials
+      NOT_FOUND_CODE = :not_found
 
       # Needed for #authenticate_with_http_token
       include ActionController::HttpAuthentication::Token::ControllerMethods
@@ -129,7 +132,11 @@ module Api
 
         errors = JsonApiErrors.new
         status = 401 # unauthorized
-        errors.add(status: 401, detail: I18n.t('invalid_credentials'))
+        errors.add(
+          status: 401,
+          code: INVALID_CREDENTIALS_CODE,
+          detail: I18n.t('invalid_credentials')
+        )
 
         render json: errors, status: status
         false # Rails5: Should be updated to use throw
@@ -160,7 +167,11 @@ module Api
 
       def record_not_found
         errors = JsonApiErrors.new
-        errors.add(status: 404, detail: I18n.t('record_not_found'))
+        errors.add(
+          status: 404,
+          code: NOT_FOUND_CODE,
+          detail: I18n.t('record_not_found')
+        )
 
         render json: errors, status: :not_found
         false # Rails5: Should be updated to use throw
@@ -169,7 +180,11 @@ module Api
       def require_user
         unless logged_in?
           errors = JsonApiErrors.new
-          errors.add(status: 401, detail: I18n.t('not_logged_in_error'))
+          errors.add(
+            status: 401,
+            code: LOGIN_REQUIRED_CODE,
+            detail: I18n.t('not_logged_in_error')
+          )
 
           render json: errors, status: :unauthorized
         end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -84,6 +84,7 @@ module Api
 
       before_action :authenticate_user_token!
       before_action :require_promo_code
+      before_action :set_locale
 
       ALLOWED_INCLUDES = [].freeze
 
@@ -92,8 +93,6 @@ module Api
 
       # Needed for #authenticate_with_http_token
       include ActionController::HttpAuthentication::Token::ControllerMethods
-
-      before_action :set_locale
 
       after_action :verify_authorized
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -258,12 +258,8 @@ module Api
         authenticate_with_http_token do |auth_token, _options|
           token = Token.includes(:user).find_by(token: auth_token)
           return if token.nil?
-
-          if token.expired?
-            raise ExpiredTokenError
-          else
-            return @_current_user = token.user
-          end
+          return raise ExpiredTokenError if token.expired?
+          return @_current_user = token.user
         end
       end
     end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -258,7 +258,7 @@ module Api
           token = Token.includes(:user).find_by(token: auth_token)
           return if token.nil?
           return raise ExpiredTokenError if token.expired?
-          return @_current_user = token.user
+          return login_user(token.user)
         end
       end
     end

--- a/app/controllers/concerns/invalid_credentials.rb
+++ b/app/controllers/concerns/invalid_credentials.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 module InvalidCredentials
   INVALID_CREDENTIALS_CODE = :invalid_credentials
 
   def self.add(errors)
-    errors.tap do |errors|
-      errors.add(
-        status: 401,
+    errors.tap do |errs|
+      errs.add(
+        status: 403,
         code: INVALID_CREDENTIALS_CODE,
         detail: I18n.t('invalid_credentials')
       )

--- a/app/controllers/concerns/invalid_credentials.rb
+++ b/app/controllers/concerns/invalid_credentials.rb
@@ -1,0 +1,13 @@
+module InvalidCredentials
+  INVALID_CREDENTIALS_CODE = :invalid_credentials
+
+  def self.add(errors)
+    errors.tap do |errors|
+      errors.add(
+        status: 401,
+        code: INVALID_CREDENTIALS_CODE,
+        detail: I18n.t('invalid_credentials')
+      )
+    end
+  end
+end

--- a/app/controllers/concerns/login_required.rb
+++ b/app/controllers/concerns/login_required.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
 module LoginRequired
   LOGIN_REQUIRED_CODE = :login_required
 
   def self.add(errors)
-    errors.tap do |errors|
-      errors.add(
+    errors.tap do |errs|
+      errs.add(
         status: 401,
         code: LOGIN_REQUIRED_CODE,
         detail: I18n.t('not_logged_in_error')

--- a/app/controllers/concerns/login_required.rb
+++ b/app/controllers/concerns/login_required.rb
@@ -1,0 +1,13 @@
+module LoginRequired
+  LOGIN_REQUIRED_CODE = :login_required
+
+  def self.add(errors)
+    errors.tap do |errors|
+      errors.add(
+        status: 401,
+        code: LOGIN_REQUIRED_CODE,
+        detail: I18n.t('not_logged_in_error')
+      )
+    end
+  end
+end

--- a/app/controllers/concerns/not_found.rb
+++ b/app/controllers/concerns/not_found.rb
@@ -1,0 +1,13 @@
+module NotFound
+  NOT_FOUND_CODE = :not_found
+
+  def self.add(errors)
+    errors.tap do |errors|
+      errors.add(
+        status: 404,
+        code: NOT_FOUND_CODE,
+        detail: I18n.t('record_not_found')
+      )
+    end
+  end
+end

--- a/app/controllers/concerns/not_found.rb
+++ b/app/controllers/concerns/not_found.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
 module NotFound
   NOT_FOUND_CODE = :not_found
 
   def self.add(errors)
-    errors.tap do |errors|
-      errors.add(
+    errors.tap do |errs|
+      errs.add(
         status: 404,
         code: NOT_FOUND_CODE,
         detail: I18n.t('record_not_found')

--- a/app/controllers/concerns/token_expired.rb
+++ b/app/controllers/concerns/token_expired.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
 module TokenExpired
   TOKEN_EXPIRED_CODE = :token_expired
 
   def self.add(errors)
-    errors.tap do |errors|
-      errors.add(
+    errors.tap do |errs|
+      errs.add(
         status: 401,
         detail: I18n.t('token_expired_error'),
         code: TOKEN_EXPIRED_CODE

--- a/app/controllers/concerns/token_expired.rb
+++ b/app/controllers/concerns/token_expired.rb
@@ -1,0 +1,13 @@
+module TokenExpired
+  TOKEN_EXPIRED_CODE = :token_expired
+
+  def self.add(errors)
+    errors.tap do |errors|
+      errors.add(
+        status: 401,
+        detail: I18n.t('token_expired_error'),
+        code: TOKEN_EXPIRED_CODE
+      )
+    end
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 class ApplicationMailer < ActionMailer::Base
-  DEFAULT_EMAIL = 'JustArrived <hello@justarrived.se>'
+  DEFAULT_EMAIL = 'Just Arrived <hello@justarrived.se>'
   default from: DEFAULT_EMAIL
 end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -14,6 +14,10 @@ class Token < ApplicationRecord
   scope :expired, -> { where('expires_at < ?', Time.zone.now) }
   scope :not_expired, -> { where('expires_at > ?', Time.zone.now) }
 
+  def expired?
+    expires_at < Time.zone.now
+  end
+
   def regenerate_token
     self.token = SecureGenerator.token
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,7 @@ class User < ApplicationRecord
 
   STATUSES = {
     asylum_seeker: 1,
-    permanent: 2,
-    residence: 3
+    permanent_residence: 2
   }.freeze
 
   AT_UND = {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -127,16 +127,8 @@ class User < ApplicationRecord
     Token.not_expired.find_by(token: auth_token)
   end
 
-  def self.find_token!(auth_token)
-    Token.not_expired.find_by!(token: auth_token)
-  end
-
   def self.find_by_auth_token(auth_token)
     find_token(auth_token)&.user
-  end
-
-  def self.find_by_auth_token!(auth_token)
-    find_token!(auth_token).user
   end
 
   def self.find_by_phone(phone, normalize: false)

--- a/app/support/doxxer.rb
+++ b/app/support/doxxer.rb
@@ -40,6 +40,10 @@ class Doxxer
     [response, error].flatten(1).compact.join("\n")
   end
 
+  def self.read_example_file(filename)
+    File.read("#{RESPONSE_PATH}/#{filename}.json")
+  end
+
   def self.curl_for(name:, id: nil, auth: false, locale: false, join_with: ' ')
     path = [name, id].compact.join('/')
     curl_opts = []
@@ -52,6 +56,12 @@ class Doxxer
   end
 
   def self.generate_response_examples
+    # Write "global" error response examples
+    [InvalidCredentials, LoginRequired, NotFound, TokenExpired].each do |error_klass|
+      _write_general_response_error(error_klass)
+    end
+
+    # Write models eamples
     RELEVANT_DOC_MODELS.each do |klass|
       _write_response_example!(klass)
       _write_response_error_example!(klass)
@@ -59,6 +69,13 @@ class Doxxer
   end
 
   # private
+
+  def self._write_general_response_error(error_klass)
+    errors = error_klass.add(JsonApiErrors.new)
+    json = JSON.pretty_generate(errors.to_h)
+    filename = error_klass.to_s.underscore
+    File.write("#{RESPONSE_PATH}/#{filename}.json", json)
+  end
 
   def self._response_filename(model_klass, plural: false, error: false)
     model_name = _format_model_name(model_klass, plural: plural)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true
-    Bullet.raise = true # raise an error if n+1 query occurs
+    Bullet.raise = false # don't raise an error if n+1 query occurs
   end
 
   config.x.frilans_finans = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,7 +68,7 @@ en:
       must_be_available_locale: must be a supported langauge
       must_be_valid_phone_number_format: must be a valid phone number
       must_be_swedish_phone_number: must be a Swedish phone number (+46)
-      must_be_swedish_ssn: must be a valid Swedish social security number
+      must_be_swedish_ssn: must be a valid Swedish social security number or coordination number
       arrived_at_must_be_in_past: must be in the past
     validators:
       after_true: '%{field} must be true'
@@ -111,7 +111,7 @@ en:
       subject: Congrats! You have a new job match.
     job_performed:
       congrats_line: Hello %{name}!
-      contact_line: Once you both have confirmed that the job is performed the invoice will be sent and the salary will be paid out.
+      contact_line: Once you the job owner have confirmed that the job is performed the invoice will be sent and the salary will be paid out.
       job_line: The job performed was '%{name}'.
       performed_line: "%{name} has verified that the job you ordered is performed."
       subject: A job you ordered has been completed.
@@ -123,11 +123,11 @@ en:
       subject: Congrats! A job you performed has been accepted.
     magic_login_link:
       subject: Magic sign-in link
-      login_line: To login to JustArrived use the link %{url}
+      login_line: To login to Just Arrived use the link %{url}
     new_applicant:
       applicant_line: The applicant is '%{name}' and lives close to where the assignment will be carried out.
       congrats_line: Congratulations %{name}!
-      contact_line: You can preview '%{name}' profile under My jobs. You can also contact '%{name}' directly on %{email} and %{phone}.
+      contact_line: You can preview '%{name}' profile under My jobs. You can also contact '%{name}' directly on %{email} or %{phone}.
       job_line: You've got a new applicant for your job '%{name}'.
       subject: Congrats! You have a new applicant.
     new_chat_message:
@@ -146,10 +146,8 @@ en:
     statuses:
       asylum_seeker: Asylum seeker
       asylum_seeker_description: Asylum seeker
-      permanent: Permanent
-      permanent_description: Permanent
-      residence: Residence
-      residence_description: Residence
+      permanent_residence: Permanent residence
+      permanent_residence_description: Permanent residence
   notifications:
     accepted_applicant_confirmation_overdue: Accepted applicants confirmation is overdue
     accepted_applicant_withdrawn: Accepted applicant has withdrawn
@@ -163,4 +161,4 @@ en:
     new_chat_message: New chat message
   texter:
     magic_login_link:
-      login_line: JustArrived magic login link %{url}
+      login_line: Just Arrived magic login link %{url}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
   invalid_credentials: Invalid credentials.
   not_logged_in_error: Must be logged in.
   record_not_found: Record does not exist.
+  token_expired_error: Your token has expired.
   mailer:
     accepted_applicant_withdrawn:
       subject: An accepted user for your job has withdrawn the application.

--- a/config/locales/models/models.sv.yml
+++ b/config/locales/models/models.sv.yml
@@ -143,6 +143,10 @@ sv:
         job: Jobb
         score: Göra
         to_user: Till användare
+      token:
+        token: Nyckel
+        expires_at: Löper ut vid
+        user: Användare
       skill:
         job_skills: Arbetserfarenheter
         jobs: Jobb
@@ -150,10 +154,6 @@ sv:
         name: Namn
         user_skills: Användar färdigheter
         users: Användare
-      token:
-        token: Token
-        expires_at: går ut vid
-        user: Användare
       user:
         admin: Administration
         anonymized: Anonym

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -128,7 +128,7 @@ sv:
       subject: Grattis! Du har en fått en ny ansökan.
     magic_login_link:
       subject: Magisk inloggningslänk
-      login_line: För att logga in på JustArrived använd länken %{url}
+      login_line: För att logga in på Just Arrived använd länken %{url}
     new_chat_message:
       view_chat_line: Du kan också läsa meddelandet här %{url}, där kan du också få meddelandet översatt.
       received_from_line: Du har fått ett nytt meddelande från %{name}.
@@ -146,10 +146,8 @@ sv:
     statuses:
       asylum_seeker: Asylsökande
       asylum_seeker_description: Asylsökande
-      permanent: Permanent
-      permanent_description: Permanent
-      residence: Medborgare
-      residence_description: Medborgare
+      permanent_residence: Permanent
+      permanent_residence_description: Permanent
   notifications:
     accepted_applicant_confirmation_overdue: Den accepterade användarens konfirmationsperiod har gått ut
     accepted_applicant_withdrawn: Den accepterade användaren har dragit tillbaka sin ansökan
@@ -163,4 +161,4 @@ sv:
     new_chat_message: Nytt chatt meddelande
   texter:
     magic_login_link:
-      login_line: JustArrived magisk inloggningslänk %{url}
+      login_line: Just Arrived magisk inloggningslänk %{url}

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -14,32 +14,32 @@ sv:
         notice: Misslyckades skapa Frilans Finans faktura för %{id}
   errors:
     rate_limit:
-      details: För många anrop gjorda på kort tid. Försök igen om en liten stund.
+      details: Gränsvärde nått. Var god försök lite senare.
     bank_account:
       too_short: är för kort
       too_long: är för lång
-      invalid_characters: otillåtna tecken
-      bad_checksum: okänd checksumma
+      invalid_characters: ogiltiga tecken
+      bad_checksum: fel checksumma
       unknown_clearing_number: okänt clearing nummer
       iban:
         too_short: är för kort
-        bad_characters: otillåtna tecken
-        bad_check_digits: otillåtna checksiffror
-        unknown_country_code: okänd landskod
+        bad_characters: har ogiltiga tecken
+        bad_check_digits: har ogiltiga checknummer
+        unknown_country_code: 'okänd landskod '
         bad_length: har fel längd
         bad_format: har fel format
       bic:
         bad_format: har fel format
-        bad_country_code: okänd landskod
+        bad_country_code: 'okänd landskod '
     general:
       protocol_missing: Protocol prefix saknas http:// eller https://
-      must_be_valid_date: måste vara ett gilltigt datum
+      must_be_valid_date: måste vara ett giltigt datum
     chat:
       number_of_users: en chat måste bestå av minst %{min} och %{max} antal användare
     invoice:
       job_started: jobbets starttid kan inte vara i framtiden när en faktura ska skapas
       job_user_accepted: användaren måste vara accepterat innan en faktura kan bli skapad
-      job_user_will_perform: användaren måste ha bekräftat jobbet innan en faktura kan bli skapad
+      job_user_will_perform: användaren måste ha konfirmerat jobb innan en faktura kan bli skapad
     job:
       job_date_in_the_past: måste vara i framtiden
       hourly_pay_active: måste vara aktiv
@@ -56,44 +56,45 @@ sv:
       from_user_rated: kan inte rösta flera gånger
       to_user_rated: kan rösta flera gånger
       comment_user: måste vara användaren själv som gör röstningen
-      job_user_concluded: uppdrag måste vara avslutat
-      job_user_performed: uppdrag måste ha konfirmerats som utfört
+      job_user_concluded: Uppdrag måste vara avslutat
+      job_user_performed: jobbet måste vara konfirmerat innan konfirmering av utfört arbete görs
       user_allowed_to_rate: måste vara jobb ägaren eller den accepterade användaren
     user_session:
       banned: en administratör har blockerat dig eftersom du inte följt Användarvillkoren. Vad god kontakta help@justarrived.
-      wrong_email_or_phone_or_password: fel epost, telefonnummer eller lösenord
+      wrong_email_or_phone_or_password: fel email, telefonnummer eller lösenord
     user:
       wrong_password: fel lösenord
       password_length: lösenordet måste vara minst %{count} tecken
       must_be_available_locale: ditt språk stöds tyvärr inte
-      must_be_valid_phone_number_format: måste vara ett gilltigt format
-      must_be_swedish_phone_number: måste vara ett gilltigt svenskt nummer (+46)
-      must_be_swedish_ssn: måste vara ett gilltigt svenskt personnummer or samordningsnummer
+      must_be_valid_phone_number_format: måste vara ett giltigt telefonnummer
+      must_be_swedish_phone_number: måste vara ett giltigt svenskt telefonnummer (+46)
+      must_be_swedish_ssn: måste vara ett giltigt svenskt person- eller samordningsnummer
       arrived_at_must_be_in_past: måste vara i det förflutna
     validators:
       after_true: '%{field} måste vara sant'
       unrevertable: kan inte återställa %{field}
   invalid_credentials: Fel referenser.
-  record_not_found: Sidan kunde inte hittas.
+  not_logged_in_error: Måste vara inloggad.
+  record_not_found: Posten existerar inte.
   token_expired_error: Din token har upphört att gälla.
   mailer:
     accepted_applicant_withdrawn:
       subject: En accepterad användare för ditt jobb har dragit tillbaka sin ansökan.
       title: En accepterad användare för ditt jobb har dragit tillbaka sin ansökan.
-      explaination: Den accepterade användaren %{name} för jobbet %{job_name} har dragit tillbaka sin ansökan. Var god välj en annan användare.
+      explaination: Den accepterade användaren %{name} för ditt jobb %{job_name} har dragit tillbaka sin ansökan. Var god välj en annan kandidat genom att logga in på plattformen, klicka Mina uppdrag som ligger i Menyn.
     accepted_applicant_confirmation_overdue:
-      subject: En accepterad användare för ditt job har inte konfirmerat deltagandet i tid.
-      title: En accepterad användare för ditt job har inte konfirmerat deltagandet i tid.
-      explaination: Den accepterade användaren %{name} för ditt jobb %{job_name} har inte konfirmerat sitt deltagande inom den tillåtna tidsramen. Var god välj en annan användare.
+      subject: Den accepterade användaren för ditt jobb har inte konfirmerat i tid.
+      title: Den accepterade användaren för ditt jobb har inte konfirmerat i tid.
+      explaination: Den accepterade användare %{name} för ditt jobb %{job_name} har inte konfirmerat i tid. Var god välj en annan kandidat genom att logga in på plattformen och under meny klicka på Mina uppdrag.
     applicant_will_perform:
-      subject: Grattis! En användare kommer utföra ditt jobb.
+      subject: Grattis! Den accepterade användare för ditt jobb har konfirmerat.
       congrats_line: Grattis!
-      details_line: "%{name} har konfirmerat att de kommer utföra ditt jobb %{job_name}."
-      explaination: Var god kontakta %{name} via chat under fliken Mina Jobb, på %{phone} eller %{email} för att lösa potentiella detaljer.
+      details_line: "%{name} har konfirmerat ditt och kommer utföra %{job_name}."
+      explaination: Var god kontakta %{name} genom chatten under Mina jobb, på %{phone} or %{email} för att gå igenom potentiella detaljer.
     applicant_accepted:
       accepted_line: Du har blivit accepterad för ett jobb!
       congrats_line: Grattis %{name}!
-      contact_line: Kontakta %{email} för mer information.
+      contact_line: Du har 18 timmar på dig att konfirmera att du kommer utföra jobbet, var god gör det så snart du kan under Mina uppdrag i applikationen. Om du har några frågor kan du kontakta den ansvarige på email %{email} för mer detaljer.
       job_line: Jobbet är '%{name}' och ligger i ditt område.
       subject: Grattis! Du har fått jobb!
     changed_password:
@@ -109,29 +110,29 @@ sv:
       job_line: 'Jobbet är: ''%{name}'' och det ligger i ditt område.'
       subject: Grattis! Du har en ny jobbmatchning.
     job_performed:
-      congrats_line: Grattis %{name}!
-      contact_line: Om du har några sista frågor kan du kontakta dem på %{email}.
+      congrats_line: Hej %{name}!
+      contact_line: Så fort arbetsgivaren har konfirmerat att jobbet är genomfört kommer en faktura att skickas och lön kommer sedan betalas ut.
       job_line: Jobbet som utförts var '%{name}'.
       performed_line: "%{name} har verifierat att de har utfört ett jobb åt dig."
-      subject: Grattis! En jobb du har lagt upp har blivit utfört.
+      subject: Ett jobb du har beställt har blivit utfört.
     invoice_created:
       congrats_line: Grattis %{name}!
-      contact_line: Om du har några avslutande frågor kan du kontakta %{email}.
+      contact_line: Var snäll och betygsätt arbetsgivaren.
       job_line: 'Jobbet du har utfört: ''%{name}''.'
-      performed_line: "%{name} har verifierat att du har har utfört jobbet."
+      performed_line: "%{name} har verifierat att du har utfört ett jobb."
       subject: Grattis! ett jobb du har utfört har blivit accepterat.
+    magic_login_link:
+      subject: Magisk login-länk
+      login_line: Logga in på Just Arrived här %{url}
     new_applicant:
-      applicant_line: Användaren är '%{name}' och bor i ditt område.
+      applicant_line: Kandidaten är %{name} och bor i närheten av där uppdraget ska utföras.
       congrats_line: Grattis %{name}!
-      contact_line: Om du har några frågor, kan du kontakt dem på %{email} och %{phone}.
+      contact_line: Du kan förhandsgranska %{name} profil under Mina uppdrag. Du kan också kontakta %{name} direkt på %{email} eller %{phone}.
       job_line: Du har en ny ansökning till ditt jobb '%{name}'.
       subject: Grattis! Du har en fått en ny ansökan.
-    magic_login_link:
-      subject: Magisk inloggningslänk
-      login_line: För att logga in på Just Arrived använd länken %{url}
     new_chat_message:
-      view_chat_line: Du kan också läsa meddelandet här %{url}, där kan du också få meddelandet översatt.
-      received_from_line: Du har fått ett nytt meddelande från %{name}.
+      view_chat_line: Du kan läsa meddelandet här %{url}, där kan du kan du också få meddelandet översatt.
+      received_from_line: Du har fått ett meddelande från %{name}.
       subject: "Nytt meddelande från %{name}"
     reset_password:
       subject: 'Just Arrived återställ lösenords länk'
@@ -139,15 +140,14 @@ sv:
     welcome:
       subject: Välkommen till Just Arrived!
       body_header: Välkommen till Just Arrived %{name}!
-      body_line: Tack för att du har signat upp. Vi hoppas att du kommer tycka om tjänsten!
+      body_line: Tack för att du registrerat dig. Vi hoppas du kommer tycka om tjänsten. Om du har några frågor eller förslag om hur vi kan förbättra oss, får du gärna höra av dig till oss på admin@justarrived.se.
     signoff: Ha en bra dag!
-  not_logged_in_error: Måste vara inloggad.
   user:
     statuses:
       asylum_seeker: Asylsökande
       asylum_seeker_description: Asylsökande
-      permanent_residence: Permanent
-      permanent_residence_description: Permanent
+      permanent_residence: Permanent uppehållstillstånd
+      permanent_residence_description: Permanent uppehållstillstånd
   notifications:
     accepted_applicant_confirmation_overdue: Den accepterade användarens konfirmationsperiod har gått ut
     accepted_applicant_withdrawn: Den accepterade användaren har dragit tillbaka sin ansökan
@@ -158,7 +158,7 @@ sv:
     new_applicant: Ny ansökande
     user_job_match: Ny jobb matchning
     job_cancelled: Jobb avbrutet
-    new_chat_message: Nytt chatt meddelande
+    new_chat_message: Nytt chattmeddelande
   texter:
     magic_login_link:
-      login_line: Just Arrived magisk inloggningslänk %{url}
+      login_line: Just Arrived magisk login länk %{url}

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -75,6 +75,7 @@ sv:
       unrevertable: kan inte återställa %{field}
   invalid_credentials: Fel referenser.
   record_not_found: Sidan kunde inte hittas.
+  token_expired_error: Din token har upphört att gälla.
   mailer:
     accepted_applicant_withdrawn:
       subject: En accepterad användare för ditt jobb har dragit tillbaka sin ansökan.

--- a/examples/responses/invalid_credentials.json
+++ b/examples/responses/invalid_credentials.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+    {
+      "status": 401,
+      "detail": "Invalid credentials.",
+      "code": "invalid_credentials"
+    }
+  ]
+}

--- a/examples/responses/invalid_credentials.json
+++ b/examples/responses/invalid_credentials.json
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "status": 401,
+      "status": 403,
       "detail": "Invalid credentials.",
       "code": "invalid_credentials"
     }

--- a/examples/responses/login_required.json
+++ b/examples/responses/login_required.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+    {
+      "status": 401,
+      "detail": "Must be logged in.",
+      "code": "login_required"
+    }
+  ]
+}

--- a/examples/responses/not_found.json
+++ b/examples/responses/not_found.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+    {
+      "status": 404,
+      "detail": "Record does not exist.",
+      "code": "not_found"
+    }
+  ]
+}

--- a/examples/responses/token_expired.json
+++ b/examples/responses/token_expired.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+    {
+      "status": 401,
+      "detail": "Your token has expired.",
+      "code": "token_expired"
+    }
+  ]
+}

--- a/lib/json_api_helpers/lib/json_api_helpers/serializers/error.rb
+++ b/lib/json_api_helpers/lib/json_api_helpers/serializers/error.rb
@@ -10,7 +10,8 @@ module JsonApiHelpers
       end
 
       def to_h
-        response = { status: @status, code: @code, detail: @detail }
+        response = { status: @status, detail: @detail }
+        response.merge!(code: @code) unless @code.nil?
         response.merge!(@pointer)
       end
 

--- a/lib/json_api_helpers/lib/json_api_helpers/serializers/error.rb
+++ b/lib/json_api_helpers/lib/json_api_helpers/serializers/error.rb
@@ -11,7 +11,7 @@ module JsonApiHelpers
 
       def to_h
         response = { status: @status, detail: @detail }
-        response.merge!(code: @code) unless @code.nil?
+        response[:code] = @code unless @code.nil?
         response.merge!(@pointer)
       end
 

--- a/lib/json_api_helpers/lib/json_api_helpers/serializers/error.rb
+++ b/lib/json_api_helpers/lib/json_api_helpers/serializers/error.rb
@@ -2,14 +2,15 @@
 module JsonApiHelpers
   module Serializers
     class Error
-      def initialize(detail:, status: 422, pointer: nil, attribute: nil)
+      def initialize(detail:, status: 422, code: nil, pointer: nil, attribute: nil)
         @status = status
         @detail = detail
         @pointer = pointer(pointer: pointer, attribute: attribute)
+        @code = code
       end
 
       def to_h
-        response = { status: @status, detail: @detail }
+        response = { status: @status, code: @code, detail: @detail }
         response.merge!(@pointer)
       end
 

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Api::V1::SkillsController, type: :controller do
         expected = {
           'errors' => [{
             'status' => 401,
-            'code' => 'invalid_credentials',
-            'detail' => I18n.t('invalid_credentials')
+            'code' => 'login_required',
+            'detail' => I18n.t('not_logged_in_error')
           }]
         }
         expect(jsonapi_error).to eq(expected)

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Api::V1::SkillsController, type: :controller do
         expected = {
           'errors' => [{
             'status' => 401,
+            'code' => 'invalid_credentials',
             'detail' => I18n.t('invalid_credentials')
           }]
         }
@@ -71,6 +72,7 @@ RSpec.describe Api::V1::SkillsController, type: :controller do
       expected = {
         'errors' => [{
           'status' => 404,
+          'code' => 'not_found',
           'detail' => I18n.t('record_not_found')
         }]
       }

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::V1::SkillsController, type: :controller do
     it 'lets the request pass if the user is logged in' do
       user = FactoryGirl.create(:user)
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
 
       get :index, {}, {}

--- a/spec/controllers/chats/chat_messages_controller_spec.rb
+++ b/spec/controllers/chats/chat_messages_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V1::Chats::ChatMessagesController, type: :controller do
     user = @chat_user.user
     user.create_auth_token
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     { token: user.auth_token }
   end

--- a/spec/controllers/chats_controller_spec.rb
+++ b/spec/controllers/chats_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::Chats::ChatsController, type: :controller do
     user = FactoryGirl.create(:user_with_tokens)
     allow_any_instance_of(described_class).
       to(
-        receive(:authenticate_user_token!).
+        receive(:current_user).
         and_return(user)
       )
     { token: user.auth_token }

--- a/spec/controllers/jobs/acceptances_controller_spec.rb
+++ b/spec/controllers/jobs/acceptances_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::Jobs::AcceptancesController, type: :controller do
   let(:valid_session) do
     user = FactoryGirl.create(:user_with_tokens)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     { token: user.auth_token }
   end

--- a/spec/controllers/jobs/confirmations_controller_spec.rb
+++ b/spec/controllers/jobs/confirmations_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::V1::Jobs::ConfirmationsController, type: :controller do
     # Set the job_user as the logged in user
     let(:valid_session) do
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
       { token: user.auth_token }
     end

--- a/spec/controllers/jobs/invoices_controller_spec.rb
+++ b/spec/controllers/jobs/invoices_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::V1::Jobs::InvoicesController, type: :controller do
 
   let(:valid_session) do
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(logged_in_user))
 
     { token: logged_in_user.auth_token }

--- a/spec/controllers/jobs/job_comments_controller_spec.rb
+++ b/spec/controllers/jobs/job_comments_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::Jobs::JobCommentsController, type: :controller do
   let(:valid_session) do
     user = FactoryGirl.create(:user)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     {}
   end
@@ -95,7 +95,7 @@ RSpec.describe Api::V1::Jobs::JobCommentsController, type: :controller do
 
     let(:valid_session) do
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
       {}
     end
@@ -167,7 +167,7 @@ RSpec.describe Api::V1::Jobs::JobCommentsController, type: :controller do
 
     let(:valid_session) do
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
       {}
     end

--- a/spec/controllers/jobs/job_skills_controller_spec.rb
+++ b/spec/controllers/jobs/job_skills_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::Jobs::JobSkillsController, type: :controller do
   let(:valid_session) do
     user = FactoryGirl.create(:user_with_tokens)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     { token: user.auth_token }
   end

--- a/spec/controllers/jobs/job_users_controller_spec.rb
+++ b/spec/controllers/jobs/job_users_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::Jobs::JobUsersController, type: :controller do
   let(:valid_session) do
     user = FactoryGirl.create(:user_with_tokens)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     { token: user.auth_token }
   end
@@ -219,7 +219,7 @@ RSpec.describe Api::V1::Jobs::JobUsersController, type: :controller do
           # Set the job_user as the logged in user
           let(:valid_session) do
             allow_any_instance_of(described_class).
-              to(receive(:authenticate_user_token!).
+              to(receive(:current_user).
               and_return(user))
             { token: user.auth_token }
           end
@@ -278,7 +278,7 @@ RSpec.describe Api::V1::Jobs::JobUsersController, type: :controller do
           }.merge(new_performed_attributes)
 
           allow_any_instance_of(described_class).
-            to(receive(:authenticate_user_token!).
+            to(receive(:current_user).
             and_return(user))
 
           notifier_args = { job_user: job_user, owner: job.owner }
@@ -316,7 +316,7 @@ RSpec.describe Api::V1::Jobs::JobUsersController, type: :controller do
         user = job.users.first
         job_user = job.job_users.first
         allow_any_instance_of(described_class).
-          to(receive(:authenticate_user_token!).
+          to(receive(:current_user).
           and_return(user))
         session = { token: user.auth_token }
         params = { job_id: job.to_param, job_user_id: job_user.to_param }
@@ -331,7 +331,7 @@ RSpec.describe Api::V1::Jobs::JobUsersController, type: :controller do
         job_user = job.job_users.first
         job.job_users.first.update_attributes(accepted: true, will_perform: true)
         allow_any_instance_of(described_class).
-          to(receive(:authenticate_user_token!).
+          to(receive(:current_user).
           and_return(user))
         session = { token: user.auth_token }
         params = { job_id: job.to_param, job_user_id: job_user.to_param }
@@ -352,7 +352,7 @@ RSpec.describe Api::V1::Jobs::JobUsersController, type: :controller do
         job_user = job.job_users.first
         job.job_users.first.update_attributes(accepted: true)
         allow_any_instance_of(described_class).
-          to(receive(:authenticate_user_token!).
+          to(receive(:current_user).
           and_return(user))
         session = { token: user.auth_token }
         params = { job_id: job.to_param, job_user_id: job_user.to_param }
@@ -366,7 +366,7 @@ RSpec.describe Api::V1::Jobs::JobUsersController, type: :controller do
         user = job.users.first
         job_user = job.job_users.first
         allow_any_instance_of(described_class).
-          to(receive(:authenticate_user_token!).
+          to(receive(:current_user).
           and_return(user))
         session = { token: user.auth_token }
         params = { job_id: job.to_param, job_user_id: job_user.to_param }

--- a/spec/controllers/jobs/performed_controller_spec.rb
+++ b/spec/controllers/jobs/performed_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::Jobs::PerformedController, type: :controller do
   # Set the job_user as the logged in user
   let(:valid_session) do
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     { token: user.auth_token }
   end
@@ -36,7 +36,7 @@ RSpec.describe Api::V1::Jobs::PerformedController, type: :controller do
     }
 
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
 
     notifier_args = { job_user: job_user, owner: job.owner }

--- a/spec/controllers/jobs/ratings_controller_spec.rb
+++ b/spec/controllers/jobs/ratings_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Api::V1::Jobs::RatingsController do
 
   let(:valid_session) do
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(job_owner))
     { token: job_owner.auth_token }
   end

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Api::V1::JobsController, type: :controller do
   let(:valid_session) do
     user = FactoryGirl.create(:user_with_tokens)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     { token: user.auth_token }
   end
@@ -42,7 +42,7 @@ RSpec.describe Api::V1::JobsController, type: :controller do
   let(:valid_admin_session) do
     admin = FactoryGirl.create(:admin_user)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(admin))
     { token: admin.auth_token }
   end
@@ -50,7 +50,7 @@ RSpec.describe Api::V1::JobsController, type: :controller do
   let(:invalid_session) do
     user = FactoryGirl.create(:user)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(nil))
     { token: user.auth_token }
   end
@@ -91,7 +91,7 @@ RSpec.describe Api::V1::JobsController, type: :controller do
       company = FactoryGirl.create(:company)
       user = FactoryGirl.create(:user, company: company)
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
       { token: user.auth_token }
     end
@@ -231,7 +231,7 @@ RSpec.describe Api::V1::JobsController, type: :controller do
         let(:valid_session) do
           user = FactoryGirl.create(:user_with_tokens)
           allow_any_instance_of(described_class).
-            to(receive(:authenticate_user_token!).
+            to(receive(:current_user).
             and_return(user))
           { token: user.auth_token }
         end

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Api::V1::JobsController, type: :controller do
     user = FactoryGirl.create(:user)
     allow_any_instance_of(described_class).
       to(receive(:current_user).
-      and_return(nil))
+      and_return(User.new))
     { token: user.auth_token }
   end
 

--- a/spec/controllers/terms_agreement_consent_controller_spec.rb
+++ b/spec/controllers/terms_agreement_consent_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::Jobs::TermsAgreementConsentsController, type: :controlle
 
   let(:valid_session) do
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     {}
   end

--- a/spec/controllers/users/change_password_controller_spec.rb
+++ b/spec/controllers/users/change_password_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::Users::ChangePasswordController, type: :controller do
 
       let(:valid_session) do
         allow_any_instance_of(described_class).
-          to(receive(:authenticate_user_token!).
+          to(receive(:current_user).
           and_return(user))
         {}
       end

--- a/spec/controllers/users/frilans_finans_controller_spec.rb
+++ b/spec/controllers/users/frilans_finans_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V1::Users::FrilansFinansController, type: :controller do
 
     let(:valid_session) do
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
       {}
     end

--- a/spec/controllers/users/messages_controller_spec.rb
+++ b/spec/controllers/users/messages_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::Users::MessagesController, type: :controller do
   let(:valid_session) do
     user = FactoryGirl.create(:user)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     {}
   end

--- a/spec/controllers/users/owned_jobs_controller_spec.rb
+++ b/spec/controllers/users/owned_jobs_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::Users::OwnedJobsController, type: :controller do
   let(:valid_session) do
     allow_any_instance_of(described_class).
       to(
-        receive(:authenticate_user_token!).
+        receive(:current_user).
         and_return(user)
       )
     {}

--- a/spec/controllers/users/ratings_controller_spec.rb
+++ b/spec/controllers/users/ratings_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::V1::Users::RatingsController, type: :controller do
   let(:valid_params) { { user_id: user.to_param } }
   let(:valid_session) do
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     {}
   end

--- a/spec/controllers/users/user_chats_controller_spec.rb
+++ b/spec/controllers/users/user_chats_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::Users::UserChatsController, type: :controller do
   let(:user) { FactoryGirl.create(:user) }
   let(:valid_session) do
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     {}
   end

--- a/spec/controllers/users/user_images_controller_spec.rb
+++ b/spec/controllers/users/user_images_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::Users::UserImagesController, type: :controller do
     let(:user_image) { FactoryGirl.create(:user_image, user: user) }
     let(:valid_session) do
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
       {}
     end

--- a/spec/controllers/users/user_jobs_controller_spec.rb
+++ b/spec/controllers/users/user_jobs_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::V1::Users::UserJobsController, type: :controller do
   let(:valid_session) do
     allow_any_instance_of(described_class).
       to(
-        receive(:authenticate_user_token!).
+        receive(:current_user).
         and_return(user)
       )
     {}

--- a/spec/controllers/users/user_languages_controller_spec.rb
+++ b/spec/controllers/users/user_languages_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::Users::UserLanguagesController, type: :controller do
   let(:valid_session) do
     user = FactoryGirl.create(:user_with_tokens)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     { token: user.auth_token }
   end
@@ -25,7 +25,7 @@ RSpec.describe Api::V1::Users::UserLanguagesController, type: :controller do
       user = FactoryGirl.create(:user_with_languages, languages_count: 1)
 
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
 
       user_language = user.user_languages.first

--- a/spec/controllers/users/user_skills_controller_spec.rb
+++ b/spec/controllers/users/user_skills_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::Users::UserSkillsController, type: :controller do
   let(:valid_session) do
     user = FactoryGirl.create(:user_with_tokens)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     { token: user.auth_token }
   end
@@ -22,7 +22,7 @@ RSpec.describe Api::V1::Users::UserSkillsController, type: :controller do
     it 'assigns all user skills as @skills' do
       user = FactoryGirl.create(:user_with_skills, skills_count: 1)
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
 
       user_skill = user.user_skills.first
@@ -33,7 +33,7 @@ RSpec.describe Api::V1::Users::UserSkillsController, type: :controller do
     it 'returns 200 ok status' do
       user = FactoryGirl.create(:user)
       allow_any_instance_of(described_class).
-        to(receive(:authenticate_user_token!).
+        to(receive(:current_user).
         and_return(user))
       get :index, { user_id: user.to_param }, {}
       expect(response.status).to eq(200)
@@ -102,7 +102,7 @@ RSpec.describe Api::V1::Users::UserSkillsController, type: :controller do
     context 'not authorized' do
       it 'returns not authorized status' do
         allow_any_instance_of(described_class).
-          to(receive(:authenticate_user_token!).
+          to(receive(:current_user).
           and_return(nil))
         user = FactoryGirl.create(:user)
         post :create, { user_id: user.to_param, skill: {} }, {}
@@ -133,7 +133,7 @@ RSpec.describe Api::V1::Users::UserSkillsController, type: :controller do
         user = FactoryGirl.create(:user_with_skills)
         user.create_auth_token
         allow_any_instance_of(described_class).
-          to(receive(:authenticate_user_token!).
+          to(receive(:current_user).
           and_return(user))
         { token: user.auth_token }
       end

--- a/spec/controllers/users/user_skills_controller_spec.rb
+++ b/spec/controllers/users/user_skills_controller_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Api::V1::Users::UserSkillsController, type: :controller do
       it 'returns not authorized status' do
         allow_any_instance_of(described_class).
           to(receive(:current_user).
-          and_return(nil))
+          and_return(User.new))
         user = FactoryGirl.create(:user)
         post :create, { user_id: user.to_param, skill: {} }, {}
         expect(response.status).to eq(401)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
   let(:valid_session) do
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(logged_in_user))
     { token: logged_in_user.auth_token }
   end
@@ -46,7 +46,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   let(:valid_admin_session) do
     user = FactoryGirl.create(:user, admin: true)
     allow_any_instance_of(described_class).
-      to(receive(:authenticate_user_token!).
+      to(receive(:current_user).
       and_return(user))
     { token: user.auth_token }
   end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -2,6 +2,24 @@
 require 'rails_helper'
 
 RSpec.describe Token, type: :model do
+  describe '#expired?' do
+    context 'valid token' do
+      let(:token) { FactoryGirl.create(:token) }
+
+      it 'returns false' do
+        expect(token.expired?).to eq(false)
+      end
+    end
+
+    context 'expired token' do
+      let(:token) { FactoryGirl.create(:expired_token) }
+
+      it 'returns true' do
+        expect(token.expired?).to eq(true)
+      end
+    end
+  end
+
   describe '#default_expires_at' do
     it 'sets default expires at if unset' do
       token = described_class.new

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -568,7 +568,7 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'valid token' do
+    context 'expired token' do
       it 'returns nil' do
         token = FactoryGirl.create(:expired_token)
 

--- a/spec/requests/base_controller_spec.rb
+++ b/spec/requests/base_controller_spec.rb
@@ -2,11 +2,68 @@
 require 'rails_helper'
 
 RSpec.describe 'BaseController', type: :request do
-  before(:each) do
-    FactoryGirl.create(:job, short_description: 'shortdescription')
+  describe 'authenticate_user_token!' do
+    context 'with valid token' do
+      let(:token) { FactoryGirl.create(:token) }
+      let(:auth_header) do
+        encoded_token =  ActionController::HttpAuthentication::Token.encode_credentials(token.token) # rubocop:disable Metrics/LineLength
+        { 'HTTP_AUTHORIZATION' => encoded_token }
+      end
+
+      it 'returns user if passed valid token' do
+        user = token.user
+
+        get api_v1_user_path(user_id: user.id), nil, auth_header
+
+        parsed_body = JSON.parse(response.body)
+        first_name = parsed_body.dig('data', 'attributes', 'first-name')
+
+        expect(first_name).to eq('Jane')
+      end
+    end
+
+    context 'with invalid token' do
+      let(:token) { FactoryGirl.create(:token) }
+      let(:auth_header) do
+        encoded_token =  ActionController::HttpAuthentication::Token.encode_credentials('notavalidtoken') # rubocop:disable Metrics/LineLength
+        { 'HTTP_AUTHORIZATION' => encoded_token }
+      end
+
+      it 'returns unauthorized if passed invalid token' do
+        user = token.user
+
+        get api_v1_user_path(user_id: user.id), nil, auth_header
+
+        expect(response.code).to eq('401')
+      end
+    end
+
+    context 'with expired token' do
+      let(:token) { FactoryGirl.create(:expired_token) }
+      let(:auth_header) do
+        encoded_token =  ActionController::HttpAuthentication::Token.encode_credentials(token.token) # rubocop:disable Metrics/LineLength
+        { 'HTTP_AUTHORIZATION' => encoded_token }
+      end
+
+      it 'returns unauthorized if passed invalid token' do
+        user = token.user
+
+        get api_v1_user_path(user_id: user.id), nil, auth_header
+
+        parsed_body = JSON.parse(response.body)
+        errors = parsed_body.dig('errors').first
+        expect(errors['status']).to eq(401)
+        expect(errors['detail']).to eq(I18n.t('token_expired_error'))
+        expect(errors['code']).to eq(Api::V1::BaseController::TOKEN_EXPIRED_CODE.to_s)
+      end
+    end
   end
 
   describe 'key transform header' do
+    before(:each) do
+      FactoryGirl.create(:job, short_description: 'shortdescription')
+    end
+
     context 'with X-API-KEY-TRANSFORM underscore' do
       it 'returns all keys in underscore format' do
         get api_v1_jobs_path, headers: { 'X-API-KEY-TRANSFORM' => 'underscore' }

--- a/spec/requests/base_controller_spec.rb
+++ b/spec/requests/base_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'BaseController', type: :request do
     context 'with valid token' do
       let(:token) { FactoryGirl.create(:token) }
       let(:auth_header) do
-        encoded_token =  ActionController::HttpAuthentication::Token.encode_credentials(token.token) # rubocop:disable Metrics/LineLength
+        encoded_token = ActionController::HttpAuthentication::Token.encode_credentials(token.token) # rubocop:disable Metrics/LineLength
         { 'HTTP_AUTHORIZATION' => encoded_token }
       end
 
@@ -25,7 +25,7 @@ RSpec.describe 'BaseController', type: :request do
     context 'with invalid token' do
       let(:token) { FactoryGirl.create(:token) }
       let(:auth_header) do
-        encoded_token =  ActionController::HttpAuthentication::Token.encode_credentials('notavalidtoken') # rubocop:disable Metrics/LineLength
+        encoded_token = ActionController::HttpAuthentication::Token.encode_credentials('notavalidtoken') # rubocop:disable Metrics/LineLength
         { 'HTTP_AUTHORIZATION' => encoded_token }
       end
 
@@ -41,7 +41,7 @@ RSpec.describe 'BaseController', type: :request do
     context 'with expired token' do
       let(:token) { FactoryGirl.create(:expired_token) }
       let(:auth_header) do
-        encoded_token =  ActionController::HttpAuthentication::Token.encode_credentials(token.token) # rubocop:disable Metrics/LineLength
+        encoded_token = ActionController::HttpAuthentication::Token.encode_credentials(token.token) # rubocop:disable Metrics/LineLength
         { 'HTTP_AUTHORIZATION' => encoded_token }
       end
 

--- a/spec/requests/base_controller_spec.rb
+++ b/spec/requests/base_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'BaseController', type: :request do
         errors = parsed_body.dig('errors').first
         expect(errors['status']).to eq(401)
         expect(errors['detail']).to eq(I18n.t('token_expired_error'))
-        expect(errors['code']).to eq(Api::V1::BaseController::TOKEN_EXPIRED_CODE.to_s)
+        expect(errors['code']).to eq('token_expired')
       end
     end
   end


### PR DESCRIPTION
If an expired token is used the API response will be:


```json
{
  "errors": [{
    "status": 401,
    "code": "token_expired",
    "detail": "Your token has expired."
  }]
}
```

Closes #586