### PR TITLE
Don't require user ssn

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -69,7 +69,7 @@ module Api
           param :phone, String, desc: 'Phone', required: true
           param :street, String, desc: 'Street'
           param :zip, String, desc: 'Zip code'
-          param :ssn, String, desc: 'Social Security Number (10 characters)', required: true
+          param :ssn, String, desc: 'Social Security Number (10 characters)'
           param :ignored_notifications, Array, of: 'ignored notifications', desc: "List of ignored notifications. Any of: #{User::NOTIFICATIONS.map { |n| "`#{n}`" }.join(', ')}"
           param :company_id, Integer, desc: 'Company id for user'
           param :language_id, Integer, desc: 'Primary language id for user', required: true

--- a/app/models/frilans_finans/user_wrapper.rb
+++ b/app/models/frilans_finans/user_wrapper.rb
@@ -2,10 +2,8 @@
 module FrilansFinans
   module UserWrapper
     def self.attributes(user)
-      # Frilans Finans wants the social security number as an integer
-      # We store the ssn on the format YYMMDD-XXXX, so we need to remove '-'
-      ssn = format_ssn(user.ssn)
-      {
+      # NOTE: FFAPIv2: Wrap in data/attributes instead of user
+      attrs = {
         user: {
           email: user.email,
           street: user.street || '',
@@ -14,13 +12,20 @@ module FrilansFinans
           country: user.country_name.upcase,
           cellphone: user.phone,
           first_name: user.first_name,
-          last_name: user.last_name,
-          social_security_number: ssn
+          last_name: user.last_name
         }
       }
+
+      ssn = user.ssn
+      # Company users doesn't need to have ssn set
+      attrs[:user][:social_security_number] = format_ssn(ssn) unless ssn.nil?
+      attrs
     end
 
     def self.format_ssn(ssn)
+      # Frilans Finans wants the social security number as an integer
+      # We store the ssn on the format YYMMDD-XXXX, so we need to remove '-'
+      # NOTE: FFAPIv2: ssn should be a string!
       ssn.delete('-').to_i
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,7 @@ class User < ApplicationRecord
   validates :street, length: { minimum: 5 }, allow_blank: true
   validates :zip, length: { minimum: 5 }, allow_blank: true
   validates :password, length: { minimum: MIN_PASSWORD_LENGTH }, allow_blank: false, on: :create # rubocop:disable Metrics/LineLength
-  validates :ssn, uniqueness: true, allow_blank: false
+  validates :ssn, uniqueness: true, allow_blank: true
   validates :frilans_finans_id, uniqueness: true, allow_nil: true
   validates :country_of_origin, inclusion: { in: ISO3166::Country.translations.keys }, allow_blank: true # rubocop:disable Metrics/LineLength
 

--- a/spec/models/frilans_finans/user_wrapper_spec.rb
+++ b/spec/models/frilans_finans/user_wrapper_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe FrilansFinans::UserWrapper do
       expect(result).to eq(expected)
     end
 
+    context 'with no ssn' do
+      it 'returns no social_security_number key' do
+        user = FactoryGirl.build(:user, ssn: nil)
+        result = described_class.attributes(user)
+        expect(result[:user].key?(:social_security_number)).to eq(false)
+      end
+    end
+
     it 'returns the empty street string if no street present' do
       user = FactoryGirl.build(:user, street: nil)
       result = described_class.attributes(user)


### PR DESCRIPTION
This PR makes the `social security number` optional, since its not required for company users.

@andreaskoenig 🎈 