### PR TITLE
Add Language data to UserLanguageSerializer

### DIFF
--- a/app/models/user_language.rb
+++ b/app/models/user_language.rb
@@ -8,6 +8,19 @@ class UserLanguage < ApplicationRecord
   validates :language, presence: true, uniqueness: { scope: :user }
   validates :user, presence: true, uniqueness: { scope: :language }
   validates :proficiency, numericality: { only_integer: true }, inclusion: PROFICIENCY_RANGE, allow_nil: true # rubocop:disable Metrics/LineLength
+
+  delegate :lang_code, to: :language
+  delegate :direction, to: :language
+  delegate :system_language, to: :language
+  delegate :local_name, to: :language
+  delegate :en_name, to: :language
+  delegate :sv_name, to: :language
+  delegate :ar_name, to: :language
+  delegate :fa_name, to: :language
+  delegate :fa_af_name, to: :language
+  delegate :ku_name, to: :language
+  delegate :ti_name, to: :language
+  delegate :ps_name, to: :language
 end
 
 # == Schema Information

--- a/app/serializers/user_language_serializer.rb
+++ b/app/serializers/user_language_serializer.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 class UserLanguageSerializer < ApplicationSerializer
-  ATTRIBUTES = [:proficiency].freeze
+  LANGUAGE_ATTRIBUTES = [
+    :lang_code, :direction, :system_language, :local_name, :en_name, :sv_name, :ar_name,
+    :fa_name, :fa_af_name, :ku_name, :ti_name, :ps_name
+  ].freeze
+  ATTRIBUTES = (LANGUAGE_ATTRIBUTES + [:proficiency]).freeze
   attributes ATTRIBUTES.freeze
 
   has_one :language


### PR DESCRIPTION
Closes #650 

__Example__

`GET api/v1/users/2?include=user_languages` will now return:

```json
"included": [
  {
    "id": "1",
    "type": "user-languages",
    "attributes": {
      "lang-code": "aa",
      "direction": "ltr",
      "system-language": false,
      "proficiency": 8,
      "local-name": "Afar",
      "en-name": "Afar",
      "sv-name": "Afar",
      "ar-name": "Afar",
      "fa-name": "آفاری",
      "fa-af-name": "آفاری",
      "ku-name": "Afar",
      "ti-name": "አፋርኛ",
      "ps-name": "Afar"
    },
    "relationships": {
      "language": {
        "data": {
          "id": "112",
          "type": "languages"
        }
      },
      "user": {
        "data": {
          "id": "2",
          "type": "users"
        }
      }
    }
  }
]
```
