### PR TITLE
Add average rating and total ratings for user show endpoint

### DIFF
--- a/app/controllers/api/v1/users/user_jobs_controller.rb
+++ b/app/controllers/api/v1/users/user_jobs_controller.rb
@@ -25,8 +25,7 @@ module Api
           job_users_index = Index::JobUsersIndex.new(self)
           @job_users = job_users_index.job_users(job_user_scope)
 
-          meta = { average_score: @user.average_score }
-          api_render(@job_users, total: job_users_index.count, meta: meta)
+          api_render(@job_users, total: job_users_index.count)
         end
 
         private

--- a/app/controllers/api/v1/users/user_jobs_controller.rb
+++ b/app/controllers/api/v1/users/user_jobs_controller.rb
@@ -16,7 +16,7 @@ module Api
         error code: 401, desc: 'Unauthorized'
         error code: 404, desc: 'Not found'
         ApipieDocHelper.params(self, Index::JobUsersIndex)
-        example Doxxer.read_example(JobUser, plural: true, meta: { average_score: 4.3 })
+        example Doxxer.read_example(JobUser, plural: true)
         def index
           authorize_index(@user)
 
@@ -48,7 +48,7 @@ module Api
             scope = scope.includes(user: [:user_images, :chats])
           end
 
-          scope
+          scope.joins(user: [:received_ratings])
         end
 
         def authorize_index(user)

--- a/app/controllers/api/v1/users/user_jobs_controller.rb
+++ b/app/controllers/api/v1/users/user_jobs_controller.rb
@@ -48,7 +48,7 @@ module Api
             scope = scope.includes(user: [:user_images, :chats])
           end
 
-          scope.joins(user: [:received_ratings])
+          scope.left_outer_joins(user: [:received_ratings])
         end
 
         def authorize_index(user)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -44,11 +44,15 @@ module Api
       description 'Returns user is allowed to.'
       error code: 404, desc: 'Not found'
       ApipieDocHelper.params(self)
-      example Doxxer.read_example(User)
+      example Doxxer.read_example(User, meta: { average_score: 4.3, total_ratings_count: 5 }) # rubocop:disable Metrics/LineLength
       def show
         authorize(@user)
 
-        api_render(@user)
+        meta = {
+          average_score: @user.average_score,
+          total_ratings_count: @user.received_ratings_count
+        }
+        api_render(@user, meta: meta)
       end
 
       api :POST, '/users/', 'Create new user'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -192,12 +192,11 @@ class User < ApplicationRecord
   end
 
   def average_score
-    self.class.select('users.id, AVG(ratings.score) AS avg_score')
-      .where(id: id)
-      .joins(:received_ratings)
-      .group('users.id')
-      .first
-      &.avg_score
+    received_ratings.average(:score)
+  end
+
+  def received_ratings_count
+    received_ratings.count
   end
 
   # ActiveAdmin display name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,9 +195,7 @@ class User < ApplicationRecord
     received_ratings.average(:score)
   end
 
-  def received_ratings_count
-    received_ratings.count
-  end
+  delegate :count, to: :received_ratings, prefix: true
 
   # ActiveAdmin display name
   def display_name

--- a/app/serializers/job_user_serializer.rb
+++ b/app/serializers/job_user_serializer.rb
@@ -23,9 +23,9 @@ class JobUserSerializer < ApplicationSerializer
   attribute :rating_score do
     # Don't bother looking for a rating unless the user will perform the job
     if object.will_perform
-      object.user
-        .received_ratings
-        .detect { |rating| rating.job == object.job }
+      object.user.
+        received_ratings.
+        detect { |rating| rating.job == object.job }
         &.score
     end
   end

--- a/app/serializers/job_user_serializer.rb
+++ b/app/serializers/job_user_serializer.rb
@@ -20,8 +20,14 @@ class JobUserSerializer < ApplicationSerializer
     }
   end
 
-  attribute :rating_average do
-    object.rating_average if object.respond_to?(:rating_average)
+  attribute :rating_score do
+    # Don't bother looking for a rating unless the user will perform the job
+    if object.will_perform
+      object.user
+        .received_ratings
+        .detect { |rating| rating.job == object.job }
+        &.score
+    end
   end
 
   belongs_to :user

--- a/app/support/doxxer.rb
+++ b/app/support/doxxer.rb
@@ -16,6 +16,8 @@ class Doxxer
 
     unless meta.empty?
       model_json = JSON.parse(model_json_string)
+      model_json['meta'] ||= {}
+
       meta_json = model_json['meta'].merge(meta)
       model_json['meta'] = meta_json
       model_json_string = JSON.pretty_generate(model_json)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,10 @@ Rails.application.configure do
 
   # NOTE: This causes `fsevent: running worker failed: Resource temporarily unavailable`,
   # see https://github.com/phusion/passenger/issues/1879
+  # Detect changes using an evented update checker
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # Detect changes by polling the change of the file
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # NOTE: This causes `fsevent: running worker failed: Resource temporarily unavailable`,
+  # see https://github.com/phusion/passenger/issues/1879
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
Adds meta object to JSON response from `GET /api/v1/users/:id/`:

```json
"meta": {
  "average-score": 4,
  "total-ratings-count": 1
}
```

cc @TeodorTunev ☝️ 

adds `rating_score` to JobUser serialiser (all resources with type `job_users` will have this key):

```json
{
  "id": "97",
  "type": "job-users",
  "attributes": {
    "accepted": false,
    "accepted-at": null,
    "will-perform": false,
    "performed": false,
    "will-perform-confirmation-by": null,
    "language-id": null,
    "apply-message": null,
    "translated-text": {
      "apply-message": null,
      "language-id": null
    },
    "rating-score": null
  }
}
```

cc @bvangelov ☝️ 