### PR TITLE
Allow setting env for AppConfig & AppSecrets

### DIFF
--- a/config/app_config.rb
+++ b/config/app_config.rb
@@ -3,7 +3,15 @@ require_relative 'app_env'
 
 class AppConfig
   def self.env
-    AppEnv.new
+    @env ||= default_env
+  end
+
+  def self.env=(env)
+    @env = AppEnv.new(env: env)
+  end
+
+  def self.default_env
+    @env = AppEnv.new
   end
 
   def self.default_mailer_url_host

--- a/config/app_secrets.rb
+++ b/config/app_secrets.rb
@@ -3,7 +3,15 @@ require_relative 'app_env'
 
 class AppSecrets
   def self.env
-    AppEnv.new
+    @env ||= default_env
+  end
+
+  def self.env=(env)
+    @env = AppEnv.new(env: env)
+  end
+
+  def self.default_env
+    @env = AppEnv.new
   end
 
   def self.skylight_authentication


### PR DESCRIPTION
Allow setting env for `AppConfig` & `AppSecrets` (intended only for testing purposes)