### PR TITLE
Multilingual filters

### DIFF
--- a/app/controllers/index/base_index.rb
+++ b/app/controllers/index/base_index.rb
@@ -46,33 +46,41 @@ module Index
       filtered_records
     end
 
-    def current_size
-      # #to_unsafe_h is needed otherwise query params wont be included
-      full_params = params.to_unsafe_h
-      page_size = SafeDig.dig(full_params, 'page', 'size')
-      per_page = (page_size || PER_PAGE).to_i
-      [per_page, self.class::MAX_PER_PAGE].min
-    end
-
-    def current_page
-      page_number = SafeDig.dig(params.to_unsafe_h, 'page', 'number')
-      (page_number || 1).to_i
-    end
-
     def filter_records(records)
       Queries::Filter.filter(records, filter_params, self.class::FILTER_MATCH_TYPES)
     end
 
+    def current_size
+      @current_size ||= begin
+        # #to_unsafe_h is needed otherwise query params wont be included
+        full_params = params.to_unsafe_h
+        page_size = SafeDig.dig(full_params, 'page', 'size')
+        per_page = (page_size || PER_PAGE).to_i
+        [per_page, self.class::MAX_PER_PAGE].min
+      end
+    end
+
+    def current_page
+      @page_number ||= begin
+        page_number = SafeDig.dig(params.to_unsafe_h, 'page', 'number')
+        (page_number || 1).to_i
+      end
+    end
+
     def sort_params
-      sortable_fields = self.class::SORTABLE_FIELDS
-      default_sorting = self.class::DEFAULT_SORTING
-      JsonApiSortParams.build(params[:sort], sortable_fields, default_sorting)
+      @sort_params ||= begin
+        sortable_fields = self.class::SORTABLE_FIELDS
+        default_sorting = self.class::DEFAULT_SORTING
+        JsonApiSortParams.build(params[:sort], sortable_fields, default_sorting)
+      end
     end
 
     def filter_params
-      filterable_fields = self.class::ALLOWED_FILTERS
-      transformable = self.class::TRANSFORMABLE_FILTERS
-      JsonApiFilterParams.build(params[:filter], filterable_fields, transformable)
+      @filter_params ||= begin
+        filterable_fields = self.class::ALLOWED_FILTERS
+        transformable = self.class::TRANSFORMABLE_FILTERS
+        JsonApiFilterParams.build(params[:filter], filterable_fields, transformable)
+      end
     end
   end
 end

--- a/app/controllers/index/jobs_index.rb
+++ b/app/controllers/index/jobs_index.rb
@@ -2,8 +2,12 @@
 module Index
   class JobsIndex < BaseIndex
     # rubocop:disable Metrics/LineLength
+    FILTER_MATCH_TYPES = {
+      name: { translated: :contains },
+      description: { translated: :contains }
+    }.freeze
     TRANSFORMABLE_FILTERS = TRANSFORMABLE_FILTERS.merge(job_date: :date_range).freeze
-    ALLOWED_FILTERS = %i(id hours created_at job_date verified filled featured job_user.user_id).freeze
+    ALLOWED_FILTERS = %i(id name description hours created_at job_date verified filled featured job_user.user_id).freeze
     SORTABLE_FIELDS = %i(hours job_date name verified filled featured created_at updated_at).freeze
     # rubocop:enable Metrics/LineLength
 

--- a/app/controllers/index/languages_index.rb
+++ b/app/controllers/index/languages_index.rb
@@ -25,6 +25,8 @@ module Index
 
     def languages(scope = Language)
       @languages ||= begin
+        # We need to delete the :name attribute, otherwise we're gonna try to query
+        # a name column which doesn't exist
         query = filter_params.delete(:name)
         scope = filter_languages(scope, query) if query
         prepare_records(scope)

--- a/app/controllers/index/languages_index.rb
+++ b/app/controllers/index/languages_index.rb
@@ -2,7 +2,11 @@
 module Index
   class LanguagesIndex < BaseIndex
     MAX_PER_PAGE = 300
+    LOCALE_FIELD_NAMES = %i(
+      en_name sv_name ar_name fa_name fa_af_name ku_name ti_name ps_name
+    ).freeze
     FILTER_MATCH_TYPES = {
+      name: :starts_with,
       en_name: :starts_with,
       sv_name: :starts_with,
       ar_name: :starts_with,
@@ -12,17 +16,30 @@ module Index
       ti_name: :starts_with,
       ps_name: :starts_with
     }.freeze
-    SORTABLE_FIELDS = %i(
-      created_at lang_code direction system_language en_name sv_name ar_name fa_name
-      fa_af_name ku_name ti_name ps_name
-    ).freeze
-    ALLOWED_FILTERS = %i(
-      lang_code direction system_language
-      en_name sv_name ar_name fa_name fa_af_name ku_name ti_name ps_name
-    ).freeze
+    SORTABLE_FIELDS = (%i(
+      created_at lang_code direction system_language
+    ) + LOCALE_FIELD_NAMES).freeze
+    ALLOWED_FILTERS = (%i(
+      lang_code direction system_language name
+    ) + LOCALE_FIELD_NAMES).freeze
 
     def languages(scope = Language)
-      @languages ||= prepare_records(scope)
+      @languages ||= begin
+        query = filter_params.delete(:name)
+        scope = filter_languages(scope, query) if query
+        prepare_records(scope)
+      end
+    end
+
+    def filter_languages(scope, query)
+      search_scope = Language.none
+      LOCALE_FIELD_NAMES.each do |field_name|
+        language_scope = scope.where(
+          "lower(#{field_name}) LIKE lower(concat(?, '%'))", query
+        )
+        search_scope = search_scope.or(language_scope)
+      end
+      search_scope
     end
   end
 end

--- a/app/controllers/index/skills_index.rb
+++ b/app/controllers/index/skills_index.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 module Index
   class SkillsIndex < BaseIndex
+    FILTER_MATCH_TYPES = {
+      name: { translated: :starts_with }
+    }.freeze
+    ALLOWED_FILTERS = %i(id name).freeze
     SORTABLE_FIELDS = %i(created_at name).freeze
     MAX_PER_PAGE = 100
 

--- a/spec/models/queries/filter_spec.rb
+++ b/spec/models/queries/filter_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe Queries::Filter do
         expect(result).to eq([category])
       end
     end
+
+    context 'filter_type: translated' do
+      subject { described_class }
+
+      it 'returns correct results' do
+        skill = FactoryGirl.create(:skill_with_translation, name: 'watman')
+        skill1 = FactoryGirl.create(:skill_with_translation, name: 'wat1')
+        FactoryGirl.create(:skill_with_translation, name: 'tawnam')
+
+        filter = { name: { translated: :starts_with } }
+        result = subject.filter(Skill, { name: 'wat' }, filter)
+        expect(result).to eq([skill, skill1])
+      end
+    end
   end
 
   describe '#extract_like_query' do


### PR DESCRIPTION
Closes #794 

Adds support for

```
# jobs
GET /api/v1/jobs?filter[name]=:name
GET /api/v1/jobs?filter[description]=:description
# skills
GET /api/v1/skills?filter[name]=:name
# languages
GET /api/v1/languages?filter[name]=:name
```