### PR TITLE
Normalize user fields before validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
 
   attr_accessor :password
 
-  after_validation :set_normalized_phone, :set_normalized_ssn, :set_normalized_email, :set_normalized_bank_account # rubocop:disable Metrics/LineLength
+  before_validation :set_normalized_fields
 
   before_save :encrypt_password
 
@@ -313,6 +313,13 @@ class User < ApplicationRecord
 
   def auth_token
     auth_tokens.last&.token
+  end
+
+  def set_normalized_fields
+    set_normalized_phone
+    set_normalized_ssn
+    set_normalized_email
+    set_normalized_bank_account
   end
 
   def set_normalized_phone

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,7 +42,15 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#normalize_phone' do
+  it 'normalizes phone before validation (so unique checks work properly)' do
+    phone = '073 5000 000'
+    FactoryGirl.create(:user, phone: phone)
+    user = User.new(phone: phone)
+    user.validate
+    expect(user.errors[:phone]).to eq(['has already been taken'])
+  end
+
+  describe '#set_normalize_phone' do
     it 'normalizes phone number without country prefix' do
       user = User.new(phone: '073 5000 000')
       user.validate


### PR DESCRIPTION
Fixes a bug where duplicate phone numbers where possible.

Closes #822