### PR TITLE
Staffing & Recruiting

### DIFF
--- a/app/controllers/api/v1/jobs/confirmations_controller.rb
+++ b/app/controllers/api/v1/jobs/confirmations_controller.rb
@@ -25,15 +25,8 @@ module Api
         error code: 422, desc: 'Unprocessable entity'
         example Doxxer.read_example(JobUser, method: :update)
         def create
-          @job_user.will_perform = true
-
-          if @job_user.save
-            @job.fill_position
-            # Frilans Finans wants invoices to be pre-reported
-            FrilansFinansInvoice.create!(job_user: @job_user)
-
-            ApplicantWillPerformNotifier.call(job_user: @job_user, owner: @job.owner)
-
+          @job_user = SignJobUserService.call(job_user: @job_user, job_owner: @job.owner)
+          if @job_user.valid?
             api_render(@job_user)
           else
             api_render_errors(@job_user)

--- a/app/controllers/api/v1/jobs/job_users_controller.rb
+++ b/app/controllers/api/v1/jobs/job_users_controller.rb
@@ -104,7 +104,7 @@ module Api
             job: @job,
             user: user,
             attributes: job_user_attributes,
-            notify_users: [@job.owner]
+            job_owner: @job.owner
           )
 
           if @job_user.valid?

--- a/app/controllers/index/jobs_index.rb
+++ b/app/controllers/index/jobs_index.rb
@@ -8,10 +8,11 @@ module Index
     TRANSFORMABLE_FILTERS = TRANSFORMABLE_FILTERS.merge(job_date: :date_range).freeze
     ALLOWED_FILTERS = %i(
       id name description hours created_at job_date verified filled featured
-      staffing_job job_user.user_id
+      staffing_job direct_recruitment_job job_user.user_id
     ).freeze
     SORTABLE_FIELDS = %i(
       hours job_date name verified filled featured created_at updated_at staffing_job
+      direct_recruitment_job
     ).freeze
 
     def jobs(scope = Job)

--- a/app/controllers/index/jobs_index.rb
+++ b/app/controllers/index/jobs_index.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 module Index
   class JobsIndex < BaseIndex
-    # rubocop:disable Metrics/LineLength
     FILTER_MATCH_TYPES = {
       name: { translated: :contains },
       description: { translated: :contains }
     }.freeze
     TRANSFORMABLE_FILTERS = TRANSFORMABLE_FILTERS.merge(job_date: :date_range).freeze
-    ALLOWED_FILTERS = %i(id name description hours created_at job_date verified filled featured job_user.user_id).freeze
-    SORTABLE_FIELDS = %i(hours job_date name verified filled featured created_at updated_at).freeze
-    # rubocop:enable Metrics/LineLength
+    ALLOWED_FILTERS = %i(
+      id name description hours created_at job_date verified filled featured
+      staffing_job job_user.user_id
+    ).freeze
+    SORTABLE_FIELDS = %i(
+      hours job_date name verified filled featured created_at updated_at staffing_job
+    ).freeze
 
     def jobs(scope = Job)
       @jobs ||= begin

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -14,9 +14,11 @@ class Invoice < ApplicationRecord
   validate :validate_job_user_will_perform
 
   scope :needs_frilans_finans_activation, lambda {
-    joins(:frilans_finans_invoice).
+    joins(:frilans_finans_invoice, :job).
       where('frilans_finans_invoices.frilans_finans_id IS NOT NULL').
-      where('frilans_finans_invoices.activated = false')
+      where('frilans_finans_invoices.activated = false').
+      where('jobs.staffing_job = ?', false).
+      where('jobs.direct_recruitment_job = ?', false)
   }
 
   def name

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -353,6 +353,7 @@ end
 #  company_contact_user_id      :integer
 #  just_arrived_contact_user_id :integer
 #  city                         :string
+#  staffing_job                 :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -130,6 +130,10 @@ class Job < ApplicationRecord
     category&.name
   end
 
+  def frilans_finans_job?
+    !staffing_job && !direct_recruitment_job
+  end
+
   def ended?
     job_end_date < Time.zone.now
   end
@@ -354,6 +358,7 @@ end
 #  just_arrived_contact_user_id :integer
 #  city                         :string
 #  staffing_job                 :boolean          default(FALSE)
+#  direct_recruitment_job       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -12,7 +12,7 @@ class JobPolicy < ApplicationPolicy
     :filled, :short_description, :featured, :upcoming, :translated_text, :amount,
     :language_id, :gross_amount, :net_amount, :gross_amount_with_currency, :currency,
     :net_amount_with_currency, :city, :gross_amount_delimited, :net_amount_delimited,
-    :full_street_address, :description_html
+    :full_street_address, :description_html, :staffing_job
   ].freeze
 
   ATTRIBUTES = [
@@ -20,14 +20,14 @@ class JobPolicy < ApplicationPolicy
     :zip_latitude, :zip_longitude, :verified, :job_end_date, :filled, :short_description,
     :featured, :upcoming, :street, :amount, :translated_text, :language_id, :gross_amount,
     :net_amount, :gross_amount_with_currency, :net_amount_with_currency, :city, :currency,
-    :gross_amount_delimited, :net_amount_delimited, :full_street_address,
+    :gross_amount_delimited, :net_amount_delimited, :full_street_address, :staffing_job,
     :description_html
   ].freeze
 
   OWNER_ATTRIBUTES = [
     :description, :job_date, :street, :zip, :name, :hours, :job_end_date, :cancelled,
     :city, :filled, :short_description, :featured, :upcoming, :currency,
-    :gross_amount_delimited, :net_amount_delimited, :full_street_address,
+    :gross_amount_delimited, :net_amount_delimited, :full_street_address, :staffing_job,
     :description_html, :language_id, :category_id, :hourly_pay_id, skill_ids: []
   ].freeze
 

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -12,7 +12,7 @@ class JobPolicy < ApplicationPolicy
     :filled, :short_description, :featured, :upcoming, :translated_text, :amount,
     :language_id, :gross_amount, :net_amount, :gross_amount_with_currency, :currency,
     :net_amount_with_currency, :city, :gross_amount_delimited, :net_amount_delimited,
-    :full_street_address, :description_html, :staffing_job
+    :full_street_address, :description_html, :staffing_job, :direct_recruitment_job
   ].freeze
 
   ATTRIBUTES = [
@@ -21,14 +21,15 @@ class JobPolicy < ApplicationPolicy
     :featured, :upcoming, :street, :amount, :translated_text, :language_id, :gross_amount,
     :net_amount, :gross_amount_with_currency, :net_amount_with_currency, :city, :currency,
     :gross_amount_delimited, :net_amount_delimited, :full_street_address, :staffing_job,
-    :description_html
+    :description_html, :direct_recruitment_job
   ].freeze
 
   OWNER_ATTRIBUTES = [
     :description, :job_date, :street, :zip, :name, :hours, :job_end_date, :cancelled,
     :city, :filled, :short_description, :featured, :upcoming, :currency,
     :gross_amount_delimited, :net_amount_delimited, :full_street_address, :staffing_job,
-    :description_html, :language_id, :category_id, :hourly_pay_id, skill_ids: []
+    :description_html, :direct_recruitment_job,
+    :language_id, :category_id, :hourly_pay_id, skill_ids: []
   ].freeze
 
   def index?

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -5,7 +5,7 @@ class JobSerializer < ApplicationSerializer
     :latitude, :longitude, :language_id, :street, :zip, :zip_latitude, :zip_longitude,
     :hidden, :category_id, :hourly_pay_id, :verified, :job_end_date, :cancelled, :filled,
     :featured, :upcoming, :language_id, :gross_amount, :net_amount, :city, :currency,
-    :full_street_address
+    :full_street_address, :staffing_job
   ]
 
   link(:self) { api_v1_job_url(object) }
@@ -159,6 +159,7 @@ end
 #  company_contact_user_id      :integer
 #  just_arrived_contact_user_id :integer
 #  city                         :string
+#  staffing_job                 :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -5,7 +5,7 @@ class JobSerializer < ApplicationSerializer
     :latitude, :longitude, :language_id, :street, :zip, :zip_latitude, :zip_longitude,
     :hidden, :category_id, :hourly_pay_id, :verified, :job_end_date, :cancelled, :filled,
     :featured, :upcoming, :language_id, :gross_amount, :net_amount, :city, :currency,
-    :full_street_address, :staffing_job
+    :full_street_address, :staffing_job, :direct_recruitment_job
   ]
 
   link(:self) { api_v1_job_url(object) }
@@ -160,6 +160,7 @@ end
 #  just_arrived_contact_user_id :integer
 #  city                         :string
 #  staffing_job                 :boolean          default(FALSE)
+#  direct_recruitment_job       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -10,8 +10,8 @@ class JobSerializer < ApplicationSerializer
 
   link(:self) { api_v1_job_url(object) }
 
-  # ActiveSupport::Deprecation.warn('#amount has been depreceted, use #gross_amount')
   attribute :amount do
+    ActiveSupport::Deprecation.warn('#amount has been depreceted, use #gross_amount')
     object.gross_amount
   end
 

--- a/app/services/create_job_application_service.rb
+++ b/app/services/create_job_application_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class CreateJobApplicationService
-  def self.call(job:, user:, attributes:, notify_users: [])
+  def self.call(job:, user:, attributes:, job_owner:)
     job_user = JobUser.find_or_initialize_by(user: user, job: job)
     job_user.application_withdrawn = false
     job_user.apply_message = attributes[:apply_message]
@@ -11,9 +11,7 @@ class CreateJobApplicationService
         EnqueueCheapTranslation.call(result)
       end
 
-      notify_users.each do |owner|
-        NewApplicantNotifier.call(job_user: job_user, owner: owner)
-      end
+      NewApplicantNotifier.call(job_user: job_user, owner: job_owner)
     end
 
     job_user

--- a/app/services/sign_job_user_service.rb
+++ b/app/services/sign_job_user_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class SignJobUserService
+  def self.call(job_user:, job_owner:)
+    job_user.will_perform = true
+
+    if job_user.save
+      job_user.job.fill_position
+
+      # TODO: Only create this is its a Frilans Finans job
+      # Frilans Finans wants invoices to be pre-reported
+      FrilansFinansInvoice.create!(job_user: job_user)
+
+      ApplicantWillPerformNotifier.call(job_user: job_user, owner: job_owner)
+    end
+
+    job_user
+  end
+end

--- a/app/services/sign_job_user_service.rb
+++ b/app/services/sign_job_user_service.rb
@@ -2,16 +2,17 @@
 class SignJobUserService
   def self.call(job_user:, job_owner:)
     job_user.will_perform = true
+    return job_user unless job_user.save
 
-    if job_user.save
-      job_user.job.fill_position
+    job = job_user.job
+    job.fill_position
 
-      # TODO: Only create this is its a Frilans Finans job
+    if job.frilans_finans_job?
       # Frilans Finans wants invoices to be pre-reported
       FrilansFinansInvoice.create!(job_user: job_user)
-
-      ApplicantWillPerformNotifier.call(job_user: job_user, owner: job_owner)
     end
+
+    ApplicantWillPerformNotifier.call(job_user: job_user, owner: job_owner)
 
     job_user
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
       blank_if_field: can't be blank if %{field} is present
     chat:
       number_of_users: a chat must consist of between %{min}-%{max} number of users
+    frilans_finans_invoice:
+      job_is_frilans_finans_job: job must be a Frilans Finans job
     invoice:
       job_started: job start time must be in the passed before an invoice can be created
       job_user_accepted: user must be the accepted applicant before an invoice can be created

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -41,6 +41,8 @@ sv:
       blank_if_field: kan inte vara tom om %{field} är tom
     chat:
       number_of_users: en chat måste bestå av minst %{min} och %{max} antal användare
+    frilans_finans_invoice:
+      job_is_frilans_finans_job: jobbet måste vara ett Frilans Finans jobb
     invoice:
       job_started: jobbets starttid kan inte vara i framtiden när en faktura ska skapas
       job_user_accepted: användaren måste vara accepterat innan en faktura kan bli skapad

--- a/db/migrate/20170305175920_add_staffing_job_to_jobs.rb
+++ b/db/migrate/20170305175920_add_staffing_job_to_jobs.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddStaffingJobToJobs < ActiveRecord::Migration[5.0]
+  def change
+    add_column :jobs, :staffing_job, :boolean, default: false
+  end
+end

--- a/db/migrate/20170305181423_add_direct_recruitment_job_to_jobs.rb
+++ b/db/migrate/20170305181423_add_direct_recruitment_job_to_jobs.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddDirectRecruitmentJobToJobs < ActiveRecord::Migration[5.0]
+  def change
+    add_column :jobs, :direct_recruitment_job, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170305175920) do
+ActiveRecord::Schema.define(version: 20170305181423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -435,6 +435,7 @@ ActiveRecord::Schema.define(version: 20170305175920) do
     t.integer  "just_arrived_contact_user_id"
     t.string   "city"
     t.boolean  "staffing_job",                 default: false
+    t.boolean  "direct_recruitment_job",       default: false
     t.index ["category_id"], name: "index_jobs_on_category_id", using: :btree
     t.index ["hourly_pay_id"], name: "index_jobs_on_hourly_pay_id", using: :btree
     t.index ["language_id"], name: "index_jobs_on_language_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170305142530) do
+ActiveRecord::Schema.define(version: 20170305175920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -434,6 +434,7 @@ ActiveRecord::Schema.define(version: 20170305142530) do
     t.integer  "company_contact_user_id"
     t.integer  "just_arrived_contact_user_id"
     t.string   "city"
+    t.boolean  "staffing_job",                 default: false
     t.index ["category_id"], name: "index_jobs_on_category_id", using: :btree
     t.index ["hourly_pay_id"], name: "index_jobs_on_hourly_pay_id", using: :btree
     t.index ["language_id"], name: "index_jobs_on_language_id", using: :btree

--- a/spec/controllers/jobs/confirmations_controller_spec.rb
+++ b/spec/controllers/jobs/confirmations_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::V1::Jobs::ConfirmationsController, type: :controller do
 
     it 'fills job position' do
       post :create, params: params, headers: valid_session
-      expect(assigns(:job).position_filled?).to eq(true)
+      expect(assigns(:job).reload.position_filled?).to eq(true)
     end
 
     it 'creates frilans finans invoice' do

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -324,6 +324,7 @@ end
 #  just_arrived_contact_user_id :integer
 #  city                         :string
 #  staffing_job                 :boolean          default(FALSE)
+#  direct_recruitment_job       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -323,6 +323,7 @@ end
 #  company_contact_user_id      :integer
 #  just_arrived_contact_user_id :integer
 #  city                         :string
+#  staffing_job                 :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/factories/job_factory.rb
+++ b/spec/factories/job_factory.rb
@@ -125,6 +125,7 @@ end
 #  company_contact_user_id      :integer
 #  just_arrived_contact_user_id :integer
 #  city                         :string
+#  staffing_job                 :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/factories/job_factory.rb
+++ b/spec/factories/job_factory.rb
@@ -126,6 +126,7 @@ end
 #  just_arrived_contact_user_id :integer
 #  city                         :string
 #  staffing_job                 :boolean          default(FALSE)
+#  direct_recruitment_job       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -505,6 +505,7 @@ end
 #  just_arrived_contact_user_id :integer
 #  city                         :string
 #  staffing_job                 :boolean          default(FALSE)
+#  direct_recruitment_job       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -504,6 +504,7 @@ end
 #  company_contact_user_id      :integer
 #  just_arrived_contact_user_id :integer
 #  city                         :string
+#  staffing_job                 :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/policies/job_policy_spec.rb
+++ b/spec/policies/job_policy_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe JobPolicy do
       :description, :job_date, :street, :zip, :name, :hours, :job_end_date,
       :cancelled, :city, :filled, :short_description, :featured, :upcoming,
       :currency, :gross_amount_delimited, :net_amount_delimited, :full_street_address,
-      :description_html, :language_id, :category_id, :hourly_pay_id, { skill_ids: [] }
+      :staffing_job, :description_html,
+      :language_id, :category_id, :hourly_pay_id, { skill_ids: [] }
     ]
   end
   let(:admin_params) { owner_params }

--- a/spec/policies/job_policy_spec.rb
+++ b/spec/policies/job_policy_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe JobPolicy do
       :description, :job_date, :street, :zip, :name, :hours, :job_end_date,
       :cancelled, :city, :filled, :short_description, :featured, :upcoming,
       :currency, :gross_amount_delimited, :net_amount_delimited, :full_street_address,
-      :staffing_job, :description_html,
+      :staffing_job, :description_html, :direct_recruitment_job,
       :language_id, :category_id, :hourly_pay_id, { skill_ids: [] }
     ]
   end

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -43,6 +43,7 @@ end
 #  just_arrived_contact_user_id :integer
 #  city                         :string
 #  staffing_job                 :boolean          default(FALSE)
+#  direct_recruitment_job       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -42,6 +42,7 @@ end
 #  company_contact_user_id      :integer
 #  just_arrived_contact_user_id :integer
 #  city                         :string
+#  staffing_job                 :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/routing/jobs_routing_spec.rb
+++ b/spec/routing/jobs_routing_spec.rb
@@ -65,6 +65,7 @@ end
 #  just_arrived_contact_user_id :integer
 #  city                         :string
 #  staffing_job                 :boolean          default(FALSE)
+#  direct_recruitment_job       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/routing/jobs_routing_spec.rb
+++ b/spec/routing/jobs_routing_spec.rb
@@ -64,6 +64,7 @@ end
 #  company_contact_user_id      :integer
 #  just_arrived_contact_user_id :integer
 #  city                         :string
+#  staffing_job                 :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/serializers/job_serializer_spec.rb
+++ b/spec/serializers/job_serializer_spec.rb
@@ -103,6 +103,7 @@ end
 #  company_contact_user_id      :integer
 #  just_arrived_contact_user_id :integer
 #  city                         :string
+#  staffing_job                 :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/serializers/job_serializer_spec.rb
+++ b/spec/serializers/job_serializer_spec.rb
@@ -104,6 +104,7 @@ end
 #  just_arrived_contact_user_id :integer
 #  city                         :string
 #  staffing_job                 :boolean          default(FALSE)
+#  direct_recruitment_job       :boolean          default(FALSE)
 #
 # Indexes
 #


### PR DESCRIPTION
* Extract `SignJobUserService` from `jobs/ConfirmationsController`
* Adds `Job#staffing_job` boolean (default: false) field
* Adds `Job#direct_recruitment_job` boolean (default: false) field
* Only create `FrilansFinansInvoice`s for jobs that has *not* `staffing_job` or `direct_recruitment_job` set to true
* Expose `Job#staffing_job` and `Job#direct_recruitment_job` to API and allow sort & filter
