### PR TITLE
Add ask for info notifier & add missing skills list to new applicant info email

### DIFF
--- a/app/admin/job_user.rb
+++ b/app/admin/job_user.rb
@@ -44,6 +44,16 @@ ActiveAdmin.register JobUser do
     end
   end
 
+  batch_action :ask_for_job_information, confirm: I18n.t('admin.job_user.batch_action.ask_for_job_information.confirm') do |ids| # rubocop:disable Metrics/LineLength
+    job_users = collection.where(id: ids)
+    job_users.each do |job_user|
+      AskForJobInformationJob.perform_later(job_user)
+    end
+
+    notice = I18n.t('admin.job_user.batch_action.ask_for_job_information.success')
+    redirect_to collection_path, notice: notice
+  end
+
   batch_action :shortlist, confirm: I18n.t('admin.job_user.batch_action.shortlist.confirm') do |ids| # rubocop:disable Metrics/LineLength
     job_users = collection.where(id: ids)
     job_users.map { |job_user| job_user.update(shortlisted: true) }

--- a/app/jobs/ask_for_job_information_job.rb
+++ b/app/jobs/ask_for_job_information_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AskForJobInformationJob < ApplicationJob
+  def perform(job_user)
+    AskForJobInformationNotifier.call(job_user: job_user)
+  end
+end

--- a/app/mailers/job_mailer.rb
+++ b/app/mailers/job_mailer.rb
@@ -30,10 +30,13 @@ class JobMailer < ApplicationMailer
     mail(to: owner.contact_email, subject: subject)
   end
 
-  def new_applicant_job_info_email(job_user:)
+  def new_applicant_job_info_email(job_user:, skills:)
     user = job_user.user
     @user_name = user.first_name
     @job_name = job_user.job.name
+
+    @skill_names = skills.map(&:name)
+    @user_edit_url = FrontendRouter.draw(:user_edit, id: user.id)
 
     subject = I18n.t('mailer.new_applicant_job_info.subject')
     mail(to: user.contact_email, subject: subject)
@@ -174,5 +177,16 @@ class JobMailer < ApplicationMailer
 
     subject = I18n.t('mailer.new_job_comment.subject')
     mail(to: owner.contact_email, subject: subject)
+  end
+
+  def ask_for_information_email(job:, user:, skills:)
+    @job_name = job.name
+    @user_name = user.name
+
+    @skill_names = skills.map(&:name)
+    @user_edit_url = FrontendRouter.draw(:user_edit, id: user.id)
+
+    subject = I18n.t('mailer.job_ask_for_information.subject')
+    mail(to: user.contact_email, subject: subject)
   end
 end

--- a/app/notifiers/ask_for_job_information_notifier.rb
+++ b/app/notifiers/ask_for_job_information_notifier.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class AskForJobInformationNotifier < BaseNotifier
+  def self.call(job_user:)
+    job = job_user.job
+    user = job_user.user
+    missing_skills = job.skills - user.skills
+
+    return if missing_skills.empty?
+
+    notify(user: user, locale: user.locale) do
+      JobMailer.
+        ask_for_information_email(user: user, job: job, skills: missing_skills)
+    end
+  end
+end

--- a/app/notifiers/new_applicant_notifier.rb
+++ b/app/notifiers/new_applicant_notifier.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class NewApplicantNotifier < BaseNotifier
-  def self.call(job_user:, owner:)
+  def self.call(job_user:, owner:, skills:)
     notify(user: owner, locale: owner.locale) do
       JobMailer.
         new_applicant_email(job_user: job_user, owner: owner)
@@ -8,7 +8,7 @@ class NewApplicantNotifier < BaseNotifier
 
     user = job_user.user
     notify(user: user, locale: user.locale) do
-      JobMailer.new_applicant_job_info_email(job_user: job_user)
+      JobMailer.new_applicant_job_info_email(job_user: job_user, skills: skills)
     end
   end
 end

--- a/app/services/create_job_application_service.rb
+++ b/app/services/create_job_application_service.rb
@@ -11,7 +11,10 @@ class CreateJobApplicationService
         EnqueueCheapTranslation.call(result)
       end
 
-      NewApplicantNotifier.call(job_user: job_user, owner: job_owner)
+      missing_skills = job.skills - user.skills
+      NewApplicantNotifier.call(
+        job_user: job_user, owner: job_owner, skills: missing_skills
+      )
     end
 
     job_user

--- a/app/views/job_mailer/ask_for_information_email.html.erb
+++ b/app/views/job_mailer/ask_for_information_email.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <%= simple_format I18n.t(
+      'mailer.job_ask_for_information.body',
+      user_name: @user_name,
+      job_name: @job_name,
+      skill_names: @skill_names.map { |s| content_tag(:em, s) }.to_sentence,
+      user_edit_url: link_to(@user_edit_url, @user_edit_url)
+    ).html_safe %>
+
+    <p><%= I18n.t('mailer.signoff') %></p>
+  </body>
+</html>

--- a/app/views/job_mailer/ask_for_information_email.text.erb
+++ b/app/views/job_mailer/ask_for_information_email.text.erb
@@ -1,0 +1,9 @@
+<%= I18n.t(
+  'mailer.job_ask_for_information.body',
+  user_name: @user_name,
+  job_name: @job_name,
+  skill_names: @skill_names.to_sentence,
+  user_edit_url: @user_edit_url
+) %>
+
+<%= I18n.t('mailer.signoff') %>

--- a/app/views/job_mailer/new_applicant_job_info_email.html.erb
+++ b/app/views/job_mailer/new_applicant_job_info_email.html.erb
@@ -8,7 +8,18 @@
       'mailer.new_applicant_job_info.body',
       name: @user_name,
       job_name: @job_name
-    ) %>
+    ).html_safe %>
+
+    <%= simple_format I18n.t(
+      'mailer.new_applicant_job_info.body_skill_fillout_notice',
+      skill_names: @skill_names.map { |s| content_tag(:em, s) }.to_sentence
+    ).html_safe unless @skill_names.empty? %>
+
+    <%= simple_format I18n.t(
+      'mailer.new_applicant_job_info.body_edit_profile',
+      url: link_to(@user_edit_url, @user_edit_url)
+    ).html_safe %>
+
     <p><%= I18n.t('mailer.signoff') %></p>
   </body>
 </html>

--- a/app/views/job_mailer/new_applicant_job_info_email.text.erb
+++ b/app/views/job_mailer/new_applicant_job_info_email.text.erb
@@ -4,4 +4,14 @@
   job_name: @job_name
 ) %>
 
+<%= I18n.t(
+  'mailer.new_applicant_job_info.body_skill_fillout_notice',
+  skill_names: @skill_names.to_sentence
+) unless @skill_names.empty? %>
+
+<%= I18n.t(
+  'mailer.new_applicant_job_info.body_edit_profile',
+  url: @user_edit_url
+) %>
+
 <%= I18n.t('mailer.signoff') %>

--- a/config/frontend_routes.yml
+++ b/config/frontend_routes.yml
@@ -9,4 +9,5 @@ routes:
   job_user_for_company: 'company/job/%{job_id}/candidate/%{job_user_id}'
   job_users: 'company/job/%{job_id}/candidates'
   job_user: 'job/%{job_id}'
+  user_edit: 'users/%{id}'
   chat: 'chat/%{id}'

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -65,6 +65,9 @@ en:
     job_user:
       apply_message: Apply message
       batch_action:
+        ask_for_job_information:
+          confirm: Are you sure you want to notify all users that are missing job skills to fill those out?
+          success: Notified all users with missing skills.
         shortlist:
           confirm: Are you sure you want to shortlist these users?
           success:

--- a/config/locales/mailers/mailers.en.yml
+++ b/config/locales/mailers/mailers.en.yml
@@ -62,6 +62,16 @@ en:
         Total salary: %{total_salary} kr/h before tax
         Where:        %{address}
 
+    job_ask_for_information:
+      subject: Complete your job application
+      body: |
+        Hi %{user_name}!
+
+        We're trying to match you with a job and we want to know a little bit more about your skills in:
+
+        %{skill_names}.
+
+        If you could go to %{user_edit_url} and update your profile with the above information that would be awesome. It will greatly improve your chances of getting matched.
     changed_password:
       subject: Your Just Arrived password has been changed
       body_header: Hi %{name}, your Just Arrived password has been changed. If this wasn't you, please contact Just Arrived at help@justarrived.se
@@ -110,6 +120,9 @@ en:
         We have a lot of users and applications for our jobs, so don’t be discouraged if someone else gets the chance this time. Next time it might be you!
 
         Your best chance to get any job is to login often, apply often, and make sure that your profile is updated! We are convinced that you will get a job that suits your profile soon!
+      body_skill_fillout_notice: |
+        In order for us to match you with a job we want to know a little bit more about your skills in: %{skill_names}.
+      body_edit_profile: Edit your profile here %{url}.
     new_applicant:
       applicant_line: The candidate is %{name}.
       congrats_line: Hi %{name}!

--- a/config/locales/mailers/mailers.sv.yml
+++ b/config/locales/mailers/mailers.sv.yml
@@ -59,6 +59,16 @@ sv:
         Lön: %{hourly_gross_salary} kr/h före skatt
         Total lön: %{total_salary} kr/h före skatt
         Var: %{address}
+    job_ask_for_information:
+      subject: Gör färdigt din ansökan
+      body: |
+        Hej %{user_name}!
+
+        Vi försöker matcha dig med ett jobb och vill skulle vilja veta lite mer om dina färdigheter inom:
+
+        %{skill_names}.
+
+        Var god gå till %{user_edit_url} och uppdatera din profil med informationen ovan. Det kommer öka dina chanser att bli matchad till ett job.
     changed_password:
       subject: Ditt Just Arrived lösenord har blivit ändrat
       body_header: Hej %{name}, ditt Just Arrived lösenord har blivit ändrat. Om det här inte var du, var god kontakta Just Arrived på help@justarrived.se
@@ -107,10 +117,13 @@ sv:
         Vi har många användare och ansökningar till våra jobb, så bli inte nedslagen om någon annan får jobbet den här gången. Nästa gång kan det vara du!
 
         Din bästa chans att få ett jobb är att logga in ofta, söka jobb ofta, och se till att din profil är uppdaterad! Vi är övertygade om att du kommer få ett jobb som passar din profil snart!
+      body_skill_fillout_notice: |
+        För att kunna matcha dig med ett jobb, behöver vi veta lite mer om dina kunskaper inom %{skill_names}
+      body_edit_profile: Uppdatera din profil här %{url}
     new_applicant:
       applicant_line: Kandidaten är %{name} och bor i närheten av där uppdraget ska utföras.
       congrats_line: Grattis %{name}!
-      contact_line: "Kolla kandidaternas profile:"
+      contact_line: "Du kan förhandsgranska %{name} profil under Mina uppdrag. Du kan också kontakta %{name} direkt på %{email} eller %{phone}."
       job_line: Du har en ny ansökning till ditt jobb '%{name}'.
       subject: Grattis! Du har en fått en ny ansökan.
     new_chat_message:

--- a/config/locales/mailers/mailers.sv.yml
+++ b/config/locales/mailers/mailers.sv.yml
@@ -110,7 +110,7 @@ sv:
     new_applicant:
       applicant_line: Kandidaten är %{name} och bor i närheten av där uppdraget ska utföras.
       congrats_line: Grattis %{name}!
-      contact_line: "Du kan förhandsgranska %{name} profil under Mina uppdrag. Du kan också kontakta %{name} direkt på %{email} eller %{phone}."
+      contact_line: "Kolla kandidaternas profile:"
       job_line: Du har en ny ansökning till ditt jobb '%{name}'.
       subject: Grattis! Du har en fått en ny ansökan.
     new_chat_message:

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -4,4 +4,5 @@
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
+  config/frontend_routes.yml
 ).each { |path| Spring.watch(path) }

--- a/spec/mailers/job_mailer_spec.rb
+++ b/spec/mailers/job_mailer_spec.rb
@@ -162,8 +162,9 @@ RSpec.describe JobMailer, type: :mailer do
   end
 
   describe '#new_applicant_job_info_email' do
+    let(:skill) { FactoryGirl.create(:skill) }
     let(:mail) do
-      described_class.new_applicant_job_info_email(job_user: job_user)
+      described_class.new_applicant_job_info_email(job_user: job_user, skills: [skill])
     end
 
     it 'has both text and html part' do
@@ -189,6 +190,10 @@ RSpec.describe JobMailer, type: :mailer do
 
     it 'includes @job_name in email body' do
       expect(mail).to match_email_body(job.name)
+    end
+
+    it 'includes skill names in email body' do
+      expect(mail).to match_email_body(skill.name)
     end
   end
 

--- a/spec/mailers/job_mailer_spec.rb
+++ b/spec/mailers/job_mailer_spec.rb
@@ -516,4 +516,40 @@ RSpec.describe JobMailer, type: :mailer do
       expect(mail).to match_email_body(url)
     end
   end
+
+  describe '#ask_for_information_email' do
+    let(:job) { FactoryGirl.build(:job, owner: owner) }
+    let(:user) { FactoryGirl.build(:user) }
+    let(:skills) { [FactoryGirl.create(:skill), FactoryGirl.create(:skill)] }
+    let(:mail) do
+      described_class.ask_for_information_email(user: user, job: job, skills: skills)
+    end
+
+    it 'has both text and html part' do
+      expect(mail).to be_multipart_email(true)
+    end
+
+    it 'renders the subject' do
+      subject = I18n.t('mailer.job_ask_for_information.subject')
+      expect(mail.subject).to eql(subject)
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eql([user.contact_email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to eql(['support@email.justarrived.se'])
+    end
+
+    it 'includes missing skills list in email' do
+      expect(mail).to match_email_body(skills.first.name)
+      expect(mail).to match_email_body(skills.last.name)
+    end
+
+    it 'includes user profile edit url in email' do
+      url = FrontendRouter.draw(:user_edit, id: user.id)
+      expect(mail).to match_email_body(url)
+    end
+  end
 end

--- a/spec/mailers/previews/job_mailer_preview.rb
+++ b/spec/mailers/previews/job_mailer_preview.rb
@@ -14,7 +14,11 @@ class JobMailerPreview < ActionMailer::Preview
   end
 
   def new_applicant_job_info_email
-    JobMailer.new_applicant_job_info_email(job_user: job_user)
+    JobMailer.new_applicant_job_info_email(job_user: job_user, skills: skills)
+  end
+
+  def ask_for_information_email
+    JobMailer.ask_for_information_email(job: job, user: user, skills: skills)
   end
 
   def applicant_accepted_email
@@ -60,6 +64,10 @@ class JobMailerPreview < ActionMailer::Preview
 
   def user
     job_user.user
+  end
+
+  def skills
+    Skill.last(2)
   end
 
   def owner

--- a/spec/notifiers/ask_for_information_notifier_spec.rb
+++ b/spec/notifiers/ask_for_information_notifier_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AskForJobInformationNotifier, type: :mailer do
+  describe '::call' do
+    let(:mailer) { Struct.new(:deliver_later).new(nil) }
+    let(:job) do
+      FactoryGirl.create(:job).tap do |j|
+        j.skills = [FactoryGirl.create(:skill)]
+      end
+    end
+    let(:job_user) { FactoryGirl.build(:job_user, job: job) }
+
+    it 'sends email' do
+      allow(JobMailer).to receive(:ask_for_information_email).and_return(mailer)
+      described_class.call(job_user: job_user)
+      mailer_args = { job: job, user: job_user.user, skills: job.skills }
+      expect(JobMailer).to have_received(:ask_for_information_email).with(mailer_args)
+    end
+  end
+end

--- a/spec/notifiers/new_applicant_notifier_spec.rb
+++ b/spec/notifiers/new_applicant_notifier_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe NewApplicantNotifier, type: :mailer do
   let(:job) { mock_model Job, owner: owner }
   let(:job_user) { mock_model JobUser, job: job, user: user }
   let(:user) { FactoryGirl.build(:user) }
+  let(:skills) { [FactoryGirl.build(:skill)] }
   let(:owner) { FactoryGirl.build(:user) }
 
   before(:each) do
@@ -14,7 +15,7 @@ RSpec.describe NewApplicantNotifier, type: :mailer do
   end
 
   it 'sends new_applicant_email mail' do
-    mailer_args = { job_user: job_user, owner: owner }
+    mailer_args = { job_user: job_user, owner: owner, skills: skills }
     NewApplicantNotifier.call(**mailer_args)
     expect(JobMailer).to have_received(:new_applicant_email).with(mailer_args)
   end

--- a/spec/notifiers/new_applicant_notifier_spec.rb
+++ b/spec/notifiers/new_applicant_notifier_spec.rb
@@ -15,14 +15,13 @@ RSpec.describe NewApplicantNotifier, type: :mailer do
   end
 
   it 'sends new_applicant_email mail' do
-    mailer_args = { job_user: job_user, owner: owner, skills: skills }
-    NewApplicantNotifier.call(**mailer_args)
-    expect(JobMailer).to have_received(:new_applicant_email).with(mailer_args)
+    NewApplicantNotifier.call(job_user: job_user, owner: owner, skills: skills)
+    expect(JobMailer).to have_received(:new_applicant_email).with(job_user: job_user, owner: owner) # rubocop:disable Metrics/LineLength
   end
 
   it 'sends new_applicant_job_info_email mail' do
-    mailer_args = { job_user: job_user, owner: owner }
+    mailer_args = { job_user: job_user, owner: owner, skills: skills }
     NewApplicantNotifier.call(**mailer_args)
-    expect(JobMailer).to have_received(:new_applicant_job_info_email).with(job_user: job_user) # rubocop:disable Metrics/LineLength
+    expect(JobMailer).to have_received(:new_applicant_job_info_email).with(job_user: job_user, skills: skills) # rubocop:disable Metrics/LineLength
   end
 end


### PR DESCRIPTION
- Add missing skill section to application email
- Add ability for admins to send "ask for information emails" connected to a job, from the job user admin view