### PR TITLE
API: Add hint to skills and languges in /missing-traits response

### DIFF
--- a/app/controllers/api/v1/jobs/users_controller.rb
+++ b/app/controllers/api/v1/jobs/users_controller.rb
@@ -22,8 +22,14 @@ module Api
             "type": "missing_user_traits",
             "attributes": {
               "city": {},
-              "skill-ids": { "ids": [1, 2] },
-              "language-ids": { "ids":[5, 6] }
+              "skill-ids": {
+                "ids": [1, 2],
+                "hint": "please add the missing skills"
+              },
+              "language-ids": {
+                "ids":[5, 6],
+                "hint": "please add the missing languages"
+              }
             }
           }
         }

--- a/app/serializers/missing_user_traits_serializer.rb
+++ b/app/serializers/missing_user_traits_serializer.rb
@@ -3,8 +3,19 @@ class MissingUserTraitsSerializer
   def self.serialize(user_attributes:, skills:, languages:, key_transform:)
     attributes = {}
     user_attributes.each { |name| attributes[name] = {} }
-    attributes[:skill_ids] = { ids: skills.map(&:id) } if skills.any?
-    attributes[:language_ids] = { ids: languages.map(&:id) } if languages.any?
+    if skills.any?
+      attributes[:skill_ids] = {
+        ids: skills.map(&:id),
+        hint: I18n.t('user.missing_skills_trait')
+      }
+    end
+
+    if languages.any?
+      attributes[:language_ids] = {
+        ids: languages.map(&:id),
+        hint: I18n.t('user.missing_languages_trait')
+      }
+    end
 
     JsonApiData.new(
       id: SecureGenerator.token(length: 32),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,8 @@ en:
   record_not_found: Record does not exist.
   token_expired_error: Your token has expired.
   user:
+    missing_skills_trait: please add all of the above skills to apply for this job
+    missing_languages_trait: please add all of the above languages to apply for this job
     statuses:
       asylum_seeker: Asylum seeker
       asylum_seeker_description: Asylum seeker

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -93,6 +93,8 @@ sv:
   record_not_found: Posten existerar inte.
   token_expired_error: Din token har upphört att gälla.
   user:
+    missing_skills_trait: lägg till alla kompetenser ovan för att söka det här jobbet
+    missing_languages_trait: lägg till alla språk ovan för att söka det här jobbet
     statuses:
       asylum_seeker: Asylsökande
       asylum_seeker_description: Asylsökande

--- a/spec/controllers/jobs/users_controller_spec.rb
+++ b/spec/controllers/jobs/users_controller_spec.rb
@@ -16,12 +16,19 @@ RSpec.describe Api::V1::Jobs::UsersController do
       it 'returns the missing traits' do
         get :missing_traits, params: { job_id: job.id, user_id: admin_user.id }
 
-        skill_ids = job.skills.map(&:id)
-        language_ids = job.languages.map(&:id)
+        skill_hash = {
+          'ids' => job.skills.map(&:id),
+          'hint' => I18n.t('user.missing_skills_trait')
+        }
+
+        language_hash = {
+          'ids' => job.languages.map(&:id),
+          'hint' => I18n.t('user.missing_languages_trait')
+        }
 
         expect(response.body).to be_jsonapi_attribute('city', {})
-        expect(response.body).to be_jsonapi_attribute('skill-ids', 'ids' => skill_ids)
-        expect(response.body).to be_jsonapi_attribute('language-ids', 'ids' => language_ids) # rubocop:disable Metrics/LineLength
+        expect(response.body).to be_jsonapi_attribute('skill-ids', skill_hash)
+        expect(response.body).to be_jsonapi_attribute('language-ids', language_hash)
       end
     end
   end


### PR DESCRIPTION
```json
{
  "data": {
    "id": "c67f8be62d3d4e722a00cd68e5970c2a",
    "type": "missing_user_traits",
    "attributes": {
      "city": {},
      "skill-ids": {
        "ids": [1, 2],
        "hint": "please add the missing skills"
      },
      "language-ids": {
        "ids":[5, 6],
        "hint": "please add the missing languages"
      }
    }
  }
}
```

cc @bex1 

Closes #1050