### PR TITLE
JsonApiHelpers: Add support for Rails 5 error details and add meta data to model error-objects

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -175,7 +175,10 @@ module Api
                     "source": {
                       "pointer": "/data/attributes/email"
                     },
-                    "detail": "has already been taken"
+                    "detail": "has already been taken",
+                    "meta": {
+                      "type": "taken"
+                    }
                   }
                 ]
               }
@@ -228,7 +231,11 @@ module Api
                     "source": {
                       "pointer": "/data/attributes/account"
                     },
-                    "detail": "is too short"
+                    "detail": "is too short",
+                    "meta": {
+                      "type": "too_short",
+                      "count": 4
+                    }
                   }
                 ]
               }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,6 +129,8 @@ class User < ApplicationRecord
   enum at_und: AT_UND
   enum gender: GENDER
 
+  attr_reader :consent
+
   include Translatable
   translates :description, :job_experience, :education, :competence_text
 

--- a/lib/json_api_helpers/lib/json_api_helpers/serializers/model_error.rb
+++ b/lib/json_api_helpers/lib/json_api_helpers/serializers/model_error.rb
@@ -3,16 +3,30 @@ module JsonApiHelpers
   module Serializers
     module ModelError
       def self.serialize(model, key_transform: JsonApiHelpers.default_key_transform)
-        model.errors.messages.flat_map do |field, errors|
-          attribute_name = KeyTransform.call(field.to_s, key_transform: key_transform)
-          errors.map do |error_message|
+        model.errors.details.flat_map do |field, errors|
+          errors.map do |error|
+            attribute_name = KeyTransform.call(field.to_s, key_transform: key_transform)
+
             {
               status: 422,
               source: { pointer: "/data/attributes/#{attribute_name}" },
-              detail: error_message
+              detail: error_message_for(model.errors, field, error),
+              meta: error_meta_for(error)
             }
           end
         end
+      end
+
+      def self.error_message_for(model_errors, field, error)
+        model_errors.generate_message(
+          field, error.fetch(:error), count: error[:count]
+        )
+      end
+
+      def self.error_meta_for(error)
+        meta = { type: error.fetch(:error) }
+        meta[:count] = error[:count] if error[:count]
+        meta
       end
     end
   end

--- a/lib/json_api_helpers/lib/json_api_helpers/serializers/model_error.rb
+++ b/lib/json_api_helpers/lib/json_api_helpers/serializers/model_error.rb
@@ -1,7 +1,36 @@
 # frozen_string_literal: true
+
+require 'set'
+
 module JsonApiHelpers
   module Serializers
     module ModelError
+      KNOWN_VALIDATION_TYPES = Set.new(%i(
+                                         accepted
+                                         blank
+                                         confirmation
+                                         empty
+                                         equal_to
+                                         even
+                                         exclusion
+                                         greater_than
+                                         greater_than_or_equal_to
+                                         inclusion
+                                         invalid
+                                         less_than
+                                         less_than_or_equal_to
+                                         not_a_number
+                                         not_an_integer
+                                         odd
+                                         other_than
+                                         present
+                                         required
+                                         taken
+                                         too_long
+                                         too_short
+                                         wrong_length
+                                       )).freeze
+
       def self.serialize(model, key_transform: JsonApiHelpers.default_key_transform)
         model.errors.details.flat_map do |field, errors|
           errors.map do |error|
@@ -24,9 +53,16 @@ module JsonApiHelpers
       end
 
       def self.error_meta_for(error)
-        meta = { type: error.fetch(:error) }
+        meta = {
+          type: error_type_for(error.fetch(:error))
+        }
         meta[:count] = error[:count] if error[:count]
         meta
+      end
+
+      def self.error_type_for(error_type)
+        return error_type if KNOWN_VALIDATION_TYPES.include?(error_type)
+        :invalid
       end
     end
   end

--- a/lib/json_api_helpers/spec/json_api_helpers/serializers/model_error_spec.rb
+++ b/lib/json_api_helpers/spec/json_api_helpers/serializers/model_error_spec.rb
@@ -1,5 +1,6 @@
 
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'active_model'
 
@@ -42,5 +43,12 @@ RSpec.describe JsonApiHelpers::Serializers::ModelError do
 
   it 'returns correct meta hash for presence error' do
     expect(blank_error[:meta]).to eq(type: :blank)
+  end
+
+  it 'returns invalid as error type for unknown types' do
+    model = ExampleModel.new
+    model.errors.add(:name, 'watman error')
+    error = described_class.serialize(model).first
+    expect(error[:meta]).to eq(type: :invalid)
   end
 end

--- a/lib/json_api_helpers/spec/json_api_helpers/serializers/model_error_spec.rb
+++ b/lib/json_api_helpers/spec/json_api_helpers/serializers/model_error_spec.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 require 'spec_helper'
 require 'active_model'
@@ -7,29 +8,39 @@ RSpec.describe JsonApiHelpers::Serializers::ModelError do
     include ActiveModel::Model
 
     attr_accessor :name
-    validates :name, length: { minimum: 3 }
+    validates :name, length: { minimum: 3 }, presence: true
   end
 
   let(:model) { ExampleModel.new.tap(&:validate) }
-  subject { described_class.serialize(model) }
+  let(:errors) { described_class.serialize(model) }
+  let(:min_error) { errors.first }
+  let(:blank_error) { errors.last }
 
   it 'returns an array' do
-    expect(subject).to be_an(Array)
+    expect(errors).to be_an(Array)
   end
 
   it 'returns 422 unprocessable entity status' do
-    expect(subject.first[:status]).to eq(422)
+    expect(min_error[:status]).to eq(422)
   end
 
   it 'returns source key' do
-    expect(subject.first[:source]).to be_a(Hash)
+    expect(min_error[:source]).to be_a(Hash)
   end
 
   it 'returns the correct pointer under source key' do
-    expect(subject.first[:source][:pointer]).to eq('/data/attributes/name')
+    expect(min_error.dig(:source, :pointer)).to eq('/data/attributes/name')
   end
 
   it 'returns an array' do
-    expect(subject.first[:detail]).to eq('is too short (minimum is 3 characters)')
+    expect(min_error[:detail]).to eq('is too short (minimum is 3 characters)')
+  end
+
+  it 'returns correct meta hash for too short error' do
+    expect(min_error[:meta]).to eq(type: :too_short, count: 3)
+  end
+
+  it 'returns correct meta hash for presence error' do
+    expect(blank_error[:meta]).to eq(type: :blank)
   end
 end


### PR DESCRIPTION
## Example

```json
[{
    "status": 422,
    "source": {
        "pointer": "/data/attributes/name"
    },
    "detail": "is too short (minimum is 3 characters)",
    "meta": {
        "type": "too_short",
        "count": 3
    }
},
{
    "status": 422,
    "source": {
        "pointer": "/data/attributes/name"
    },
    "detail": "can't be blank",
    "meta": {
        "type": "blank"
    }
}]
```