### PR TITLE
Force Rating score value to be a Float & Random FrilansFinansApi enhancements

### DIFF
--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -32,8 +32,8 @@ class Rating < ApplicationRecord
 
   def self.average_score(round: nil)
     score = average(:score)
-    score = score.round(round) if !score.nil? && round
-    score
+    score = score.round(round) if score.present? && round
+    score.to_f
   end
 
   def validate_comment_owned_by

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -32,7 +32,8 @@ class Rating < ApplicationRecord
 
   def self.average_score(round: nil)
     score = average(:score)
-    score = score.round(round) if score.present? && round
+    return unless score
+    score = score.round(round) if round
     score.to_f
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -264,8 +264,8 @@ class User < ApplicationRecord
     self
   end
 
-  def average_score
-    received_ratings.average(:score)
+  def average_score(round: nil)
+    received_ratings.average_score(round: round)
   end
 
   delegate :count, to: :received_ratings, prefix: true

--- a/lib/frilans_finans_api/lib/frilans_finans_api/client/client.rb
+++ b/lib/frilans_finans_api/lib/frilans_finans_api/client/client.rb
@@ -25,14 +25,13 @@ module FrilansFinansApi
       request.get(uri: "/invoices/#{invoice_id}/salaries", query: build_query(page: page))
     end
 
-    def users(page: 1)
-      request.get(uri: '/users', query: build_query(page: page))
+    def users(page: 1, filter: {})
+      request.get(uri: '/users', query: build_query(page: page, filter: filter))
     end
 
     def taxes(page: 1, only_standard: false)
-      filter = {}
-      filter = { filter: { standard: 1 } } if only_standard
-      request.get(uri: '/taxes', query: build_query(page: page).merge(filter))
+      filter = only_standard ? { standard: 1 } : {}
+      request.get(uri: '/taxes', query: build_query(page: page, filter: filter))
     end
 
     def invoice(id:)
@@ -73,8 +72,11 @@ module FrilansFinansApi
       { data: { attributes: attributes } }
     end
 
-    def build_query(page:)
-      { page: { number: page } }
+    def build_query(page:, filter: {})
+      {
+        page: { number: page },
+        filter: filter
+      }
     end
   end
 end

--- a/lib/frilans_finans_api/lib/frilans_finans_api/client/client.rb
+++ b/lib/frilans_finans_api/lib/frilans_finans_api/client/client.rb
@@ -25,7 +25,8 @@ module FrilansFinansApi
       request.get(uri: "/invoices/#{invoice_id}/salaries", query: build_query(page: page))
     end
 
-    def users(page: 1, filter: {})
+    def users(page: 1, email: nil)
+      filter = email ? { email: email } : {}
       request.get(uri: '/users', query: build_query(page: page, filter: filter))
     end
 

--- a/lib/frilans_finans_api/lib/frilans_finans_api/client/walker.rb
+++ b/lib/frilans_finans_api/lib/frilans_finans_api/client/walker.rb
@@ -11,14 +11,18 @@ module FrilansFinansApi
         current_page = 1
         total_pages = 2
 
+        resources = []
+
         while total_pages >= current_page
           resource_index = index(page: current_page, client: client)
           total_pages = resource_index.total_pages
 
-          yield(resource_index)
+          yield(resource_index) if block_given?
+          resources += resource_index.resources
+
           current_page += 1
         end
-        nil
+        resources
       end
     end
   end

--- a/lib/frilans_finans_api/lib/frilans_finans_api/document.rb
+++ b/lib/frilans_finans_api/lib/frilans_finans_api/document.rb
@@ -65,7 +65,7 @@ module FrilansFinansApi
     end
 
     def error_status?
-      # Consider both 300, 400 and 500-statuses as errors
+      # Consider HTTP status 3XX, 4XX and 5XX as errors
       status >= 300
     end
   end

--- a/lib/frilans_finans_api/spec/client/client_spec.rb
+++ b/lib/frilans_finans_api/spec/client/client_spec.rb
@@ -102,6 +102,36 @@ RSpec.describe FrilansFinansApi::Client do
     end
   end
 
+  describe '#users' do
+    subject { described_class.new }
+
+    it 'returns users array' do
+      json = fixture_client.read(:users)
+      url = "#{base_uri}/users?page[number]=1"
+
+      stub_request(:get, url).
+        with(default_headers).
+        to_return(status: 200, body: json, headers: {})
+
+      parsed_body = JSON.parse(subject.users.body)
+      expect(parsed_body['data']).to be_a(Array)
+    end
+
+    # The real test here is actually the request stub rather than the assertion
+    it 'can add filter param' do
+      email = 'test@example.com'
+      json = fixture_client.read(:users)
+      url = "#{base_uri}/users?filter[email]=#{email}&page[number]=1"
+
+      stub_request(:get, url).
+        with(default_headers).
+        to_return(status: 200, body: json, headers: {})
+
+      parsed_body = JSON.parse(subject.users(email: email).body)
+      expect(parsed_body['data']).to be_a(Array)
+    end
+  end
+
   describe '#create_user' do
     subject do
       json = fixture_client.read(:user)

--- a/lib/frilans_finans_api/spec/client/walker_spec.rb
+++ b/lib/frilans_finans_api/spec/client/walker_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe FrilansFinansApi::Walker do
+  describe '#walk' do
+    subject do
+      Class.new do
+        include FrilansFinansApi::Walker
+
+        def self.index(*_args)
+          OpenStruct.new(
+            resources: [1, 2, 3],
+            total_pages: 3
+          )
+        end
+      end
+    end
+
+    it 'returns all fetched resources as flat array' do
+      expect(subject.walk).to eq([1, 2, 3] * 3)
+    end
+
+    it 'returns each document to passed block' do
+      subject.walk do |document|
+        expect(document.resources).to eq([1, 2, 3])
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Return float from `Rating::average_score`
* Refactor `User#average_score` to delegate to `Rating#average_score`
* `FrilansFinansApi`:
  - Update `Document#error_status?` comment
  - Don't require passed block in `Walker` & return flat array of all fetched resources
  - Add filter support to query builder and refactor `Client#taxes`
  - Add support for filtering users based on email