### PR TITLE
Markdown support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ ruby '2.4.1'
 
 gem 'rails', '5.0.2' # Ruby on Rails MVC framework
 
+# TEXT PROCESSING
+gem 'kramdown', '~> 1.13' # Markdown <> HTML
+gem 'rinku', '~> 2.0.2' # Autolink
+
 # SERVER
 gem 'lograge', '~> 0.5' # Less verbose Rails log in production
 gem 'puma', '~> 3.8' # App server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,6 +487,7 @@ GEM
       activerecord
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
+    kramdown (1.13.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.4.1)
@@ -611,6 +612,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rinku (2.0.2)
     rspec-activemodel-mocks (1.0.3)
       activemodel (>= 3.0)
       activesupport (>= 3.0)
@@ -775,6 +777,7 @@ DEPENDENCIES
   inherited_resources (~> 1.7)
   json_api_helpers!
   kaminari (~> 1.0)
+  kramdown (~> 1.13)
   letter_opener (~> 1.4)
   listen (~> 3.1)
   lograge (~> 0.5)
@@ -794,6 +797,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n (~> 5.0)
   redis-activesupport (~> 5.0)
+  rinku (~> 2.0.2)
   rspec-activemodel-mocks (~> 1.0)
   rspec-rails (~> 3.5)
   rspec_junit_formatter (~> 0.2)
@@ -817,4 +821,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -26,3 +26,6 @@ $ ->
 $(document).on 'ready', ->
   $('#filters_sidebar_section').activeAdminFiltersVisibility
     ordering: true
+
+  $('[markdown="true"]').each (index, element) ->
+    new SimpleMDE(element: element)

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -65,7 +65,7 @@ module Translatable
         end
 
         define_method(:find_translation) do |locale: I18n.locale, fallback: true|
-          for_locale = locale.to_s
+          for_locale = locale ? locale.to_s : nil
           @_translation_for ||= {}
           @_translation_for[for_locale] ||= begin
             locale_fallbacks = I18nMeta.fallbacks(for_locale)

--- a/app/services/create_translations_service.rb
+++ b/app/services/create_translations_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require 'i18n/google_translate'
+require 'markdowner'
+require 'html_sanitizer'
 
 class CreateTranslationsService
   def self.call(translation:, from:, changed: nil, languages: nil)
@@ -67,7 +69,10 @@ class CreateTranslationsService
 
   def translate_text(text, from:, to:)
     return if text.blank?
-    translation = GoogleTranslate.translate(text, from: from, to: to, type: :plain)
-    translation.text
+    html = Markdowner.to_html(text)
+    translation = GoogleTranslate.translate(html, from: from, to: to, type: :html)
+    # NOTE: #to_markdown adds "\n" to the end of the string, so lets remove it
+    markdown = Markdowner.to_markdown(translation.text).strip
+    HTMLSanitizer.sanitize(markdown)
   end
 end

--- a/app/services/create_translations_service.rb
+++ b/app/services/create_translations_service.rb
@@ -3,6 +3,24 @@ require 'i18n/google_translate'
 
 class CreateTranslationsService
   def self.call(translation:, from:, changed: nil, languages: nil)
+    new(
+      translation: translation,
+      from: from,
+      changed: changed,
+      languages: languages
+    ).call
+  end
+
+  attr_reader :translation, :from, :changed, :languages
+
+  def initialize(translation:, from:, changed: nil, languages: nil)
+    @translation = translation
+    @from = from
+    @changed = changed
+    @languages = languages
+  end
+
+  def call
     source_translation_locale = translation.language&.locale
 
     (languages || Language.machine_translation_languages).map do |language|
@@ -10,38 +28,36 @@ class CreateTranslationsService
       # don't create an additional translation for that language
       next if source_translation_locale == language.locale
 
-      attributes = attributes_for_translation(translation, changed)
-
       if from == language.locale
         # Language has been detected, skip sending that to Google Translate and
         # create it from source instead
-        next set_translation(translation, attributes, language)
+        next set_translation(attributes_for_translation, language)
       end
 
       translated_attributes = translate_attributes(
-        attributes,
+        attributes_for_translation,
         from: from,
         to: language.locale
       )
 
-      set_translation(translation, translated_attributes, language)
+      set_translation(translated_attributes, language)
     end.compact
   end
 
-  def self.attributes_for_translation(translation, changed)
+  def attributes_for_translation
     attributes = translation.translation_attributes
     # If changed is nil then all fields will be translated
     return attributes unless changed
     attributes.slice(*changed.map(&:to_s))
   end
 
-  def self.set_translation(translation, attributes, language)
+  def set_translation(attributes, language)
     translation.
       translates_model.
       set_translation(attributes, language)
   end
 
-  def self.translate_attributes(attributes, from:, to:)
+  def translate_attributes(attributes, from:, to:)
     attributes.inject({}) do |translated, values|
       name, text = values
       translated[name] = translate_text(text, from: from, to: to)
@@ -49,7 +65,7 @@ class CreateTranslationsService
     end
   end
 
-  def self.translate_text(text, from:, to:)
+  def translate_text(text, from:, to:)
     return if text.blank?
     translation = GoogleTranslate.translate(text, from: from, to: to, type: :plain)
     translation.text

--- a/app/services/process_translation_service.rb
+++ b/app/services/process_translation_service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'i18n/detect_language'
+require 'markdowner'
 
 class ProcessTranslationService
   CONFIDENCE_THRESHOLD = 0.50
@@ -12,7 +13,8 @@ class ProcessTranslationService
 
     return if text.blank?
 
-    from = translation.language&.locale || detect_locale(text, translation)
+    html = Markdowner.to_html(text)
+    from = translation.language&.locale || detect_locale(html, translation)
     return if from.nil?
 
     CreateTranslationsJob.perform_later(

--- a/app/support/string_formatter.rb
+++ b/app/support/string_formatter.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
-class StringFormatter
-  include ActionView::Helpers::TextHelper # needed for #simple_format
 
+require 'markdowner'
+
+class StringFormatter
   def to_html(string)
     return if string.blank?
 
-    simple_format(string)
+    Markdowner.to_html(string)
   end
 
   def force_utf8(string)

--- a/app/views/admin/jobs/_form.html.arb
+++ b/app/views/admin/jobs/_form.html.arb
@@ -14,7 +14,7 @@ f.inputs(I18n.t('admin.job.form.detail_section_title')) do
   f.input :language, hint: I18n.t('admin.job.form.language_hint'), collection: Language.system_languages.order(:en_name) # rubocop:disable Metrics/LineLength
   f.input :name
   f.input :short_description
-  f.input :description
+  f.input :description, input_html: { markdown: true }
   f.input :swedish_drivers_license, hint: Arbetsformedlingen::DriversLicenseCode.codes.join(', ')
   f.input :car_required
   f.input :number_to_fill

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -205,6 +205,10 @@ ActiveAdmin.setup do |config|
   # To load a javascript file:
   #   config.register_javascript 'my_javascript.js'
 
+  # SimpleMDE - Markdown editor
+  config.register_stylesheet 'https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css'
+  config.register_javascript 'https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js'
+
   # == CSV options
   #
   # Set the CSV builder separator

--- a/lib/html_sanitizer.rb
+++ b/lib/html_sanitizer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'loofah'
+
+class HTMLSanitizer
+  def self.sanitize(html)
+    Loofah.fragment(html).scrub!(:escape).to_s
+  end
+end

--- a/lib/markdowner.rb
+++ b/lib/markdowner.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'kramdown'
+require 'rinku'
+
+module Markdowner
+  def self.to_html(markdown)
+    autolinked_markdown = Rinku.auto_link(markdown)
+    Kramdown::Document.new(autolinked_markdown, input: 'GFM').to_html
+  end
+
+  def self.to_markdown(html)
+    Kramdown::Document.new(html, html_to_native: true).to_kramdown
+  end
+end

--- a/spec/lib/html_sanitizer_spec.rb
+++ b/spec/lib/html_sanitizer_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'html_sanitizer'
+
+RSpec.describe HTMLSanitizer do
+  describe '::sanitize' do
+    it 'escapes all script tags' do
+      html = '<script>test</script>'
+      expect(HTMLSanitizer.sanitize(html)).to eq('&lt;script&gt;test&lt;/script&gt;')
+    end
+  end
+end

--- a/spec/lib/markdowner_spec.rb
+++ b/spec/lib/markdowner_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'markdowner'
+
+RSpec.describe Markdowner do
+  describe '::to_html' do
+    it 'converts markdown to HTML' do
+      markdown = '# Testing'
+      expect(Markdowner.to_html(markdown)).to eq("<h1 id=\"testing\">Testing</h1>\n")
+    end
+
+    it 'converts markdown to HTML and autolinks' do
+      markdown = 'www.example.com'
+      expected = "<p><a href=\"http://www.example.com\">www.example.com</a></p>\n"
+      expect(Markdowner.to_html(markdown)).to eq(expected)
+    end
+  end
+
+  describe '::to_markdown' do
+    it 'converts HTML to markdown' do
+      markdown = '<h1>Testing</h1>'
+      expect(Markdowner.to_markdown(markdown)).to eq("# Testing\n\n")
+    end
+  end
+end

--- a/spec/support/string_formatter_spec.rb
+++ b/spec/support/string_formatter_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe StringFormatter do
       ['', nil],
       ['   ', nil],
       [nil, nil],
-      ['Just Arrived', '<p>Just Arrived</p>'],
-      ["Just \n Arrived", "<p>Just \n<br /> Arrived</p>"]
+      ['Just Arrived', "<p>Just Arrived</p>\n"],
+      ["Just \n Arrived", "<p>Just <br />\n Arrived</p>\n"]
     ].each do |values|
       argument, expected = values
 


### PR DESCRIPTION
Add markdown support to all translated fields

Add the markdown editor SimpleMDE to all input fields that have the attribute `markdown="true"`.

Add two gems:

* `kramdown` - Markdown to HTML processing (and back again)
* `rinku` - Automatically add anchor elements for links in texts

