### PR TITLE
Additional job fields

### DIFF
--- a/app/admin/job.rb
+++ b/app/admin/job.rb
@@ -100,7 +100,10 @@ ActiveAdmin.register Job do
     translation_params = {
       name: permitted_params.dig(:job, :name),
       description: permitted_params.dig(:job, :description),
-      short_description: permitted_params.dig(:job, :short_description)
+      short_description: permitted_params.dig(:job, :short_description),
+      tasks_description: permitted_params.dig(:job, :tasks_description),
+      applicant_description: permitted_params.dig(:job, :applicant_description),
+      requirements_description: permitted_params.dig(:job, :requirements_description)
     }
     language = Language.find_by(id: permitted_params.dig(:job, :language_id))
     job.set_translation(translation_params, language)
@@ -261,6 +264,7 @@ ActiveAdmin.register Job do
       :company_contact_user_id, :just_arrived_contact_user_id, :municipality,
       :number_to_fill, :order_id, :full_time, :swedish_drivers_license, :car_required,
       :publish_on_linkedin, :publish_on_blocketjobb, :blocketjobb_category,
+      :salary_type,
       job_skills_attributes: %i(skill_id proficiency proficiency_by_admin),
       job_languages_attributes: %i(language_id proficiency proficiency_by_admin)
     ]

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -54,6 +54,9 @@ module Api
           param :name, String, desc: 'Name', required: true
           param :short_description, String, desc: 'Short description'
           param :description, String, desc: 'Description', required: true
+          param :tasks_description, String, desc: 'Tasks description'
+          param :applicant_description, String, desc: 'Applicant description'
+          param :requirements_description, String, desc: 'Requirements description'
           param :owner_user_id, Integer, desc: "User id of the job owner (please note that if you try to set an owner you are not allowed to, the error will simple be: owner can't be blank)", required: true
           param :job_date, String, desc: 'Job start date', required: true
           param :job_end_date, String, desc: 'Job end date'
@@ -120,6 +123,9 @@ module Api
           param :name, String, desc: 'Name'
           param :short_description, String, desc: 'Short description'
           param :description, String, desc: 'Description'
+          param :tasks_description, String, desc: 'Tasks description'
+          param :applicant_description, String, desc: 'Applicant description'
+          param :requirements_description, String, desc: 'Requirements description'
           param :job_date, String, desc: 'Job start date'
           param :job_end_date, String, desc: 'Job end date'
           param :hours, Float, desc: 'Estmiated completion time'

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -10,6 +10,10 @@ module AdminHelper
     end
   end
 
+  def markdown_to_html(markdown)
+    ::StringFormatter.new.to_html(markdown)&.html_safe
+  end
+
   def job_user_current_status_badge(status)
     color = '#323537' # black
     font_weight = 'normal'

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -69,6 +69,8 @@ class Company < ApplicationRecord
     )
   end
 
+  alias_method :short_description, :description
+
   def company_image_logo
     company_images.last
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -124,7 +124,8 @@ class Job < ApplicationRecord
   enum salary_type: SALARY_TYPES
 
   include Translatable
-  translates :name, :short_description, :description
+  translates :name, :short_description, :description, :tasks_description,
+             :applicant_description, :requirements_description
 
   # NOTE: This is necessary for nested activeadmin has_many form
   accepts_nested_attributes_for :job_skills, :job_languages

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -512,6 +512,9 @@ end
 #  blocketjobb_category         :string
 #  publish_at                   :datetime
 #  unpublish_at                 :datetime
+#  tasks_description            :text
+#  applicant_description        :text
+#  requirements_description     :text
 #
 # Indexes
 #

--- a/app/models/job_translation.rb
+++ b/app/models/job_translation.rb
@@ -10,15 +10,18 @@ end
 #
 # Table name: job_translations
 #
-#  id                :integer          not null, primary key
-#  locale            :string
-#  short_description :string
-#  name              :string
-#  description       :text
-#  job_id            :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  language_id       :integer
+#  id                       :integer          not null, primary key
+#  locale                   :string
+#  short_description        :string
+#  name                     :string
+#  description              :text
+#  job_id                   :integer
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  language_id              :integer
+#  tasks_description        :text
+#  applicant_description    :text
+#  requirements_description :text
 #
 # Indexes
 #

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -16,7 +16,8 @@ class JobPolicy < ApplicationPolicy
     full_street_address description_html staffing_job direct_recruitment_job
     swedish_drivers_license car_required last_application_at
     last_application_at_in_words open_for_applications starts_in_the_future
-    full_time publish_at unpublish_at
+    full_time publish_at unpublish_at tasks_description applicant_description
+    requirements_description
   ).freeze
 
   ATTRIBUTES = %i(
@@ -27,7 +28,8 @@ class JobPolicy < ApplicationPolicy
     gross_amount_delimited net_amount_delimited full_street_address staffing_job
     description_html direct_recruitment_job swedish_drivers_license car_required
     last_application_at last_application_at_in_words open_for_applications
-    starts_in_the_future full_time publish_at unpublish_at
+    starts_in_the_future full_time publish_at unpublish_at tasks_description
+    applicant_description requirements_description
   ).freeze
 
   OWNER_ATTRIBUTES = [
@@ -36,6 +38,7 @@ class JobPolicy < ApplicationPolicy
     :gross_amount_delimited, :net_amount_delimited, :full_street_address, :staffing_job,
     :description_html, :direct_recruitment_job, :owner_user_id, :swedish_drivers_license,
     :car_required, :last_application_at, :full_time, :publish_at, :unpublish_at,
+    :tasks_description, :applicant_description, :requirements_description,
     :language_id, :category_id, :hourly_pay_id, skill_ids: []
   ].freeze
 

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -21,7 +21,6 @@ class JobPolicy < ApplicationPolicy
     requirements_description_html
   ).freeze
 
-
   ATTRIBUTES = %i(
     id description job_date hours name created_at updated_at zip
     zip_latitude zip_longitude verified job_end_date filled short_description

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -39,7 +39,7 @@ class JobPolicy < ApplicationPolicy
     :description, :job_date, :street, :zip, :name, :hours, :job_end_date, :cancelled,
     :city, :filled, :short_description, :featured, :upcoming, :currency,
     :gross_amount_delimited, :net_amount_delimited, :full_street_address, :staffing_job,
-    :description_html, :direct_recruitment_job, :owner_user_id, :swedish_drivers_license,
+    :direct_recruitment_job, :owner_user_id, :swedish_drivers_license,
     :car_required, :last_application_at, :full_time, :publish_at, :unpublish_at,
     :tasks_description, :applicant_description, :requirements_description,
     :language_id, :category_id, :hourly_pay_id, skill_ids: []

--- a/app/policies/job_policy.rb
+++ b/app/policies/job_policy.rb
@@ -16,9 +16,11 @@ class JobPolicy < ApplicationPolicy
     full_street_address description_html staffing_job direct_recruitment_job
     swedish_drivers_license car_required last_application_at
     last_application_at_in_words open_for_applications starts_in_the_future
-    full_time publish_at unpublish_at tasks_description applicant_description
-    requirements_description
+    full_time publish_at unpublish_at tasks_description tasks_description_html
+    applicant_description applicant_description_html requirements_description
+    requirements_description_html
   ).freeze
+
 
   ATTRIBUTES = %i(
     id description job_date hours name created_at updated_at zip
@@ -29,7 +31,8 @@ class JobPolicy < ApplicationPolicy
     description_html direct_recruitment_job swedish_drivers_license car_required
     last_application_at last_application_at_in_words open_for_applications
     starts_in_the_future full_time publish_at unpublish_at tasks_description
-    applicant_description requirements_description
+    tasks_description_html applicant_description applicant_description_html
+    requirements_description requirements_description_html
   ).freeze
 
   OWNER_ATTRIBUTES = [

--- a/app/serializers/company_serializer.rb
+++ b/app/serializers/company_serializer.rb
@@ -7,7 +7,6 @@ class CompanySerializer < ApplicationSerializer
   link(:self) { api_v1_company_url(object) }
 
   has_many :company_images
-  has_many :users, if: -> { scope.fetch(:current_user) }
 end
 
 # == Schema Information

--- a/app/serializers/company_serializer.rb
+++ b/app/serializers/company_serializer.rb
@@ -6,6 +6,8 @@ class CompanySerializer < ApplicationSerializer
 
   link(:self) { api_v1_company_url(object) }
 
+  attribute :short_description { object.short_description }
+
   has_many :company_images
 end
 

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -177,6 +177,9 @@ end
 #  blocketjobb_category         :string
 #  publish_at                   :datetime
 #  unpublish_at                 :datetime
+#  tasks_description            :text
+#  applicant_description        :text
+#  requirements_description     :text
 #
 # Indexes
 #

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -29,12 +29,42 @@ class JobSerializer < ApplicationSerializer
     to_html(object.original_description)
   end
 
+  attribute :tasks_description do
+    object.original_tasks_description
+  end
+
+  attribute :tasks_description_html do
+    to_html(object.original_tasks_description)
+  end
+
+  attribute :applicant_description do
+    object.original_applicant_description
+  end
+
+  attribute :applicant_description_html do
+    to_html(object.original_applicant_description)
+  end
+
+  attribute :requirements_description do
+    object.original_requirements_description
+  end
+
+  attribute :requirements_description_html do
+    to_html(object.original_requirements_description)
+  end
+
   attribute :translated_text do
     {
       name: object.translated_name,
       short_description: object.translated_short_description,
       description: object.translated_description,
       description_html: to_html(object.translated_description),
+      tasks_description: object.translated_tasks_description,
+      tasks_description_html: to_html(object.translated_tasks_description),
+      applicant_description: object.translated_applicant_description,
+      applicant_description_html: to_html(object.translated_applicant_description),
+      requirements_description: object.translated_requirements_description,
+      requirements_description_html: to_html(object.translated_requirements_description),
       language_id: object.translated_language_id
     }
   end

--- a/app/views/admin/jobs/_form.html.arb
+++ b/app/views/admin/jobs/_form.html.arb
@@ -17,6 +17,9 @@ f.inputs(I18n.t('admin.job.form.detail_section_title')) do
   f.input :name
   f.input :short_description
   f.input :description, input_html: { markdown: true }
+  f.input :tasks_description, input_html: { markdown: true }
+  f.input :applicant_description, input_html: { markdown: true }
+  f.input :requirements_description, input_html: { markdown: true }
   f.input :swedish_drivers_license, hint: Arbetsformedlingen::DriversLicenseCode.codes.join(', ')
   f.input :car_required
   f.input :number_to_fill

--- a/app/views/admin/jobs/_show.html.arb
+++ b/app/views/admin/jobs/_show.html.arb
@@ -19,9 +19,10 @@ panel(I18n.t('admin.job.show.general')) do
     row :municipality
     row :swedish_drivers_license
     row :car_required
-    row :description do |job|
-      StringFormatter.new.to_html(job.description).html_safe  # rubocop:disable Rails/OutputSafety, Metrics/LineLength
-    end
+    row :description { |job| markdown_to_html(job.description) }
+    row :tasks { |job| markdown_to_html(job.tasks_description) }
+    row :applicant { |job| markdown_to_html(job.applicant_description) }
+    row :requirements { |job| markdown_to_html(job.requirements_description) }
     row :skills { |job| job_skills_badges(job_skills: job.job_skills) }
     row :languages { |job| job_languages_badges(job_languages: job.job_languages) }
   end

--- a/db/migrate/20170608112244_add_additional_description_fields_to_jobs.rb
+++ b/db/migrate/20170608112244_add_additional_description_fields_to_jobs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddAdditionalDescriptionFieldsToJobs < ActiveRecord::Migration[5.1]
+  def change
+    # Job table
+    add_column :jobs, :tasks_description, :text
+    add_column :jobs, :applicant_description, :text
+    add_column :jobs, :requirements_description, :text
+    # JobTranslation table
+    add_column :job_translations, :tasks_description, :text
+    add_column :job_translations, :applicant_description, :text
+    add_column :job_translations, :requirements_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170607082953) do
+ActiveRecord::Schema.define(version: 20170608112244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "hstore"
-  enable_extension "pg_stat_statements"
   enable_extension "unaccent"
 
   create_table "active_admin_comments", id: :serial, force: :cascade do |t|
@@ -23,8 +21,8 @@ ActiveRecord::Schema.define(version: 20170607082953) do
     t.text "body"
     t.string "resource_id", null: false
     t.string "resource_type", null: false
-    t.integer "author_id"
     t.string "author_type"
+    t.integer "author_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
@@ -139,8 +137,8 @@ ActiveRecord::Schema.define(version: 20170607082953) do
 
   create_table "comments", id: :serial, force: :cascade do |t|
     t.text "body"
-    t.integer "commentable_id"
     t.string "commentable_type"
+    t.integer "commentable_id"
     t.integer "owner_user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -415,6 +413,9 @@ ActiveRecord::Schema.define(version: 20170607082953) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "language_id"
+    t.text "tasks_description"
+    t.text "applicant_description"
+    t.text "requirements_description"
     t.index ["job_id"], name: "index_job_translations_on_job_id"
     t.index ["language_id"], name: "index_job_translations_on_language_id"
   end
@@ -481,9 +482,9 @@ ActiveRecord::Schema.define(version: 20170607082953) do
     t.string "city"
     t.boolean "staffing_job", default: false
     t.boolean "direct_recruitment_job", default: false
-    t.integer "order_id"
     t.string "municipality"
     t.integer "number_to_fill", default: 1
+    t.integer "order_id"
     t.boolean "full_time", default: false
     t.string "swedish_drivers_license"
     t.boolean "car_required", default: false
@@ -494,6 +495,9 @@ ActiveRecord::Schema.define(version: 20170607082953) do
     t.string "blocketjobb_category"
     t.datetime "publish_at"
     t.datetime "unpublish_at"
+    t.text "tasks_description"
+    t.text "applicant_description"
+    t.text "requirements_description"
     t.index ["category_id"], name: "index_jobs_on_category_id"
     t.index ["hourly_pay_id"], name: "index_jobs_on_hourly_pay_id"
     t.index ["language_id"], name: "index_jobs_on_language_id"

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -298,6 +298,9 @@ end
 #  blocketjobb_category         :string
 #  publish_at                   :datetime
 #  unpublish_at                 :datetime
+#  tasks_description            :text
+#  applicant_description        :text
+#  requirements_description     :text
 #
 # Indexes
 #

--- a/spec/factories/job_factory.rb
+++ b/spec/factories/job_factory.rb
@@ -181,6 +181,9 @@ end
 #  blocketjobb_category         :string
 #  publish_at                   :datetime
 #  unpublish_at                 :datetime
+#  tasks_description            :text
+#  applicant_description        :text
+#  requirements_description     :text
 #
 # Indexes
 #

--- a/spec/factories/job_translation_factory.rb
+++ b/spec/factories/job_translation_factory.rb
@@ -14,15 +14,18 @@ end
 #
 # Table name: job_translations
 #
-#  id                :integer          not null, primary key
-#  locale            :string
-#  short_description :string
-#  name              :string
-#  description       :text
-#  job_id            :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  language_id       :integer
+#  id                       :integer          not null, primary key
+#  locale                   :string
+#  short_description        :string
+#  name                     :string
+#  description              :text
+#  job_id                   :integer
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  language_id              :integer
+#  tasks_description        :text
+#  applicant_description    :text
+#  requirements_description :text
 #
 # Indexes
 #

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -681,6 +681,9 @@ end
 #  blocketjobb_category         :string
 #  publish_at                   :datetime
 #  unpublish_at                 :datetime
+#  tasks_description            :text
+#  applicant_description        :text
+#  requirements_description     :text
 #
 # Indexes
 #

--- a/spec/models/job_translation_spec.rb
+++ b/spec/models/job_translation_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe JobTranslation, type: :model do
       :job_translation,
       name: 'Wat',
       short_description: 'Short',
-      description: 'Desc'
+      description: 'Desc',
+      tasks_description: 'Task Desc',
+      applicant_description: 'App Desc',
+      requirements_description: 'Req Desc'
     )
   end
 
@@ -30,7 +33,10 @@ RSpec.describe JobTranslation, type: :model do
 
     it 'returns a list of changed translation attributes' do
       subject.name = 'Watwoman'
-      expected = %w(short_description description)
+      expected = %w(
+        short_description description tasks_description applicant_description
+        requirements_description
+      )
       expect(subject.unchanged_translation_fields).to eq(expected)
     end
   end
@@ -47,7 +53,10 @@ RSpec.describe JobTranslation, type: :model do
       expected = {
         'name' => 'Wat',
         'short_description' => 'Short',
-        'description' => 'Desc'
+        'description' => 'Desc',
+        'tasks_description' => 'Task Desc',
+        'applicant_description' => 'App Desc',
+        'requirements_description' => 'Req Desc'
       }
       expect(result).to eq(expected)
     end

--- a/spec/models/job_translation_spec.rb
+++ b/spec/models/job_translation_spec.rb
@@ -58,15 +58,18 @@ end
 #
 # Table name: job_translations
 #
-#  id                :integer          not null, primary key
-#  locale            :string
-#  short_description :string
-#  name              :string
-#  description       :text
-#  job_id            :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  language_id       :integer
+#  id                       :integer          not null, primary key
+#  locale                   :string
+#  short_description        :string
+#  name                     :string
+#  description              :text
+#  job_id                   :integer
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  language_id              :integer
+#  tasks_description        :text
+#  applicant_description    :text
+#  requirements_description :text
 #
 # Indexes
 #

--- a/spec/policies/job_policy_spec.rb
+++ b/spec/policies/job_policy_spec.rb
@@ -12,9 +12,10 @@ RSpec.describe JobPolicy do
       :description, :job_date, :street, :zip, :name, :hours, :job_end_date,
       :cancelled, :city, :filled, :short_description, :featured, :upcoming,
       :currency, :gross_amount_delimited, :net_amount_delimited, :full_street_address,
-      :staffing_job, :description_html, :direct_recruitment_job, :owner_user_id,
+      :staffing_job, :direct_recruitment_job, :owner_user_id,
       :swedish_drivers_license, :car_required, :last_application_at, :full_time,
-      :publish_at, :unpublish_at,
+      :publish_at, :unpublish_at, :tasks_description, :applicant_description,
+      :requirements_description,
       :language_id, :category_id, :hourly_pay_id, { skill_ids: [] }
     ]
   end

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -58,6 +58,9 @@ end
 #  blocketjobb_category         :string
 #  publish_at                   :datetime
 #  unpublish_at                 :datetime
+#  tasks_description            :text
+#  applicant_description        :text
+#  requirements_description     :text
 #
 # Indexes
 #

--- a/spec/routing/jobs_routing_spec.rb
+++ b/spec/routing/jobs_routing_spec.rb
@@ -80,6 +80,9 @@ end
 #  blocketjobb_category         :string
 #  publish_at                   :datetime
 #  unpublish_at                 :datetime
+#  tasks_description            :text
+#  applicant_description        :text
+#  requirements_description     :text
 #
 # Indexes
 #

--- a/spec/serializers/job_serializer_spec.rb
+++ b/spec/serializers/job_serializer_spec.rb
@@ -30,7 +30,13 @@ RSpec.describe JobSerializer, type: :serializer do
         'description' => nil,
         'description_html' => nil,
         'short_description' => nil,
-        'language_id' => nil
+        'language_id' => nil,
+        'tasks_description' => nil,
+        'tasks_description_html' => nil,
+        'applicant_description' => nil,
+        'applicant_description_html' => nil,
+        'requirements_description' => nil,
+        'requirements_description_html' => nil
       }
       expect(subject).to have_jsonapi_attribute('translated_text', value)
     end

--- a/spec/serializers/job_serializer_spec.rb
+++ b/spec/serializers/job_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe JobSerializer, type: :serializer do
       gross_amount_with_currency net_amount_with_currency
       gross_amount_delimited net_amount_delimited description_html
       last_application_at_in_words open_for_applications starts_in_the_future
+      tasks_description_html applicant_description_html requirements_description_html
     )
     (JobPolicy::ATTRIBUTES - ignore_fields).each do |attribute|
       it "has #{attribute.to_s.humanize.downcase}" do

--- a/spec/serializers/job_serializer_spec.rb
+++ b/spec/serializers/job_serializer_spec.rb
@@ -119,6 +119,9 @@ end
 #  blocketjobb_category         :string
 #  publish_at                   :datetime
 #  unpublish_at                 :datetime
+#  tasks_description            :text
+#  applicant_description        :text
+#  requirements_description     :text
 #
 # Indexes
 #


### PR DESCRIPTION
__DB__:

Adds fields to `jobs` & `jobs_translations` table:

- `tasks_description`
- `applicant_description`
- `requirements_description`

__API__:

`JobsSerializer`:

- `tasks_description`
- `applicant_description`
- `requirements_description`
- `tasks_description_html`
- `applicant_description_html`
- `requirements_description_html` 
- and the same keys under the `translated_text`-key

`CompaniesSerializer`

- `short_description`
