### PR TITLE
active_model_serializers upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     active_admin_datetimepicker (0.5.0)
       xdan-datetimepicker-rails (~> 2.5.1)
     active_admin_theme (1.0.3)
-    active_model_serializers (0.10.5)
+    active_model_serializers (0.10.6)
       actionpack (>= 4.1, < 6)
       activemodel (>= 4.1, < 6)
       case_transform (>= 0.2)

--- a/app/serializers/chat_user_serializer.rb
+++ b/app/serializers/chat_user_serializer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ChatUserSerializer < ApplicationSerializer
-  has_one :chat
-  has_one :user
+  belongs_to :chat
+  belongs_to :user
 end
 
 # == Schema Information

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -21,8 +21,8 @@ class CommentSerializer < ApplicationSerializer
     }
   end
 
-  has_one :owner
-  has_one :language
+  belongs_to :owner
+  belongs_to :language
 end
 # rubocop:disable Metrics/LineLength
 

--- a/app/serializers/company_image_serializer.rb
+++ b/app/serializers/company_image_serializer.rb
@@ -12,7 +12,7 @@ class CompanyImageSerializer < ApplicationSerializer
 
   link(:self) { api_v1_company_image_url(object.company_id, object) if object.company_id }
 
-  has_one :company
+  belongs_to :company
 
   def category_name
     'logo'

--- a/app/serializers/interest_serializer.rb
+++ b/app/serializers/interest_serializer.rb
@@ -7,7 +7,7 @@ class InterestSerializer < ApplicationSerializer
 
   link(:self) { api_v1_interest_url(object) }
 
-  has_one :language
+  belongs_to :language
 
   attribute :translated_text do
     { name: object.translated_name, language_id: object.translated_language_id }

--- a/app/serializers/job_language_serializer.rb
+++ b/app/serializers/job_language_serializer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class JobLanguageSerializer < ApplicationSerializer
-  has_one :job
-  has_one :language
+  belongs_to :job
+  belongs_to :language
 end
 
 # == Schema Information

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -106,9 +106,9 @@ class JobSerializer < ApplicationSerializer
   has_many :job_languages, unless: :collection_serializer?
   has_many :job_skills, unless: :collection_serializer?
 
-  has_one :responsible_recruiter { object.just_arrived_contact }
+  belongs_to :responsible_recruiter { object.just_arrived_contact }
 
-  has_one :owner do
+  belongs_to :owner do
     owner_object = if object.upcoming
                      object.owner.anonymize
                    else
@@ -122,7 +122,7 @@ class JobSerializer < ApplicationSerializer
     owner_object
   end
 
-  has_one :company do
+  belongs_to :company do
     # Anonymize the company if the job is upcoming
     company_object = if object.upcoming
                        object.company&.anonymize
@@ -137,15 +137,15 @@ class JobSerializer < ApplicationSerializer
     company_object
   end
 
-  has_one :language do
+  belongs_to :language do
     link(:self) { api_v1_language_url(object.language_id) if object.language_id }
   end
 
-  has_one :category do
+  belongs_to :category do
     link(:self) { api_v1_category_url(object.category_id) if object.category_id }
   end
 
-  has_one :hourly_pay do
+  belongs_to :hourly_pay do
     link(:self) { api_v1_hourly_pay_url(object.hourly_pay_id) if object.hourly_pay_id }
   end
 

--- a/app/serializers/job_skill_serializer.rb
+++ b/app/serializers/job_skill_serializer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class JobSkillSerializer < ApplicationSerializer
-  has_one :job
-  has_one :skill
+  belongs_to :job
+  belongs_to :skill
 end
 
 # == Schema Information

--- a/app/serializers/job_user_serializer.rb
+++ b/app/serializers/job_user_serializer.rb
@@ -35,10 +35,10 @@ class JobUserSerializer < ApplicationSerializer
     end
   end
 
-  has_one :user
-  has_one :job
+  belongs_to :user
+  belongs_to :job
 
-  has_one :language do
+  belongs_to :language do
     link(:self) { api_v1_language_url(object.language_id) if object.language_id }
   end
 

--- a/app/serializers/language_serializer.rb
+++ b/app/serializers/language_serializer.rb
@@ -12,7 +12,7 @@ class LanguageSerializer < ApplicationSerializer
     object.name_for(I18n.locale)
   end
 
-  has_one :language { scope.fetch(:current_language) }
+  belongs_to :language { scope.fetch(:current_language) }
 
   attribute :language_id { scope.fetch(:current_language_id) }
 

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -36,10 +36,6 @@ class MessageSerializer < ApplicationSerializer
   has_many :company_images do
     object.author.company&.company_images
   end
-
-  has_many :company_images do
-    object.author.company&.company_images
-  end
 end
 
 # == Schema Information

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -29,7 +29,7 @@ class MessageSerializer < ApplicationSerializer
     object.author.company
   end
 
-  has_one :user_images do
+  has_many :user_images do
     object.author.user_images
   end
 

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -21,9 +21,9 @@ class MessageSerializer < ApplicationSerializer
     }
   end
 
-  has_one :chat
-  has_one :language
-  has_one :author
+  belongs_to :chat
+  belongs_to :language
+  belongs_to :author
 
   has_one :company do
     object.author.company

--- a/app/serializers/rating_serializer.rb
+++ b/app/serializers/rating_serializer.rb
@@ -5,9 +5,9 @@ class RatingSerializer < ApplicationSerializer
 
   attributes ATTRIBUTES
 
-  has_one :job
-  has_one :to_user
-  has_one :comment
+  belongs_to :job
+  belongs_to :to_user
+  belongs_to :comment
 end
 
 # == Schema Information

--- a/app/serializers/skill_serializer.rb
+++ b/app/serializers/skill_serializer.rb
@@ -7,7 +7,7 @@ class SkillSerializer < ApplicationSerializer
 
   link(:self) { api_v1_skill_url(object) }
 
-  has_one :language
+  belongs_to :language
 
   attribute :translated_text do
     { name: object.translated_name, language_id: object.translated_language_id }

--- a/app/serializers/user_document_serializer.rb
+++ b/app/serializers/user_document_serializer.rb
@@ -6,8 +6,8 @@ class UserDocumentSerializer < ApplicationSerializer
 
   attribute :category_name
 
-  has_one :user
-  has_one :document
+  belongs_to :user
+  belongs_to :document
 
   def category_name
     object.category

--- a/app/serializers/user_image_serializer.rb
+++ b/app/serializers/user_image_serializer.rb
@@ -12,7 +12,7 @@ class UserImageSerializer < ApplicationSerializer
 
   link(:self) { api_v1_user_image_url(object.user_id, object) if object.user_id }
 
-  has_one :user
+  belongs_to :user
 
   def image_url
     object.image.url

--- a/app/serializers/user_language_serializer.rb
+++ b/app/serializers/user_language_serializer.rb
@@ -4,8 +4,8 @@ class UserLanguageSerializer < ApplicationSerializer
   ATTRIBUTES = [:proficiency].freeze
   attributes ATTRIBUTES
 
-  has_one :language
-  has_one :user
+  belongs_to :language
+  belongs_to :user
 end
 
 # == Schema Information

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -45,15 +45,15 @@ class UserSerializer < ApplicationSerializer
     }
   end
 
-  has_one :company do
+  belongs_to :company do
     link(:self) { api_v1_company_url(object.company) if object.company }
   end
 
-  has_one :language do
+  belongs_to :language do
     link(:self) { api_v1_language_url(object.language_id) if object.language_id }
   end
 
-  has_one :system_language do
+  belongs_to :system_language do
     link(:self) do
       api_v1_language_url(object.system_language_id) if object.system_language_id
     end


### PR DESCRIPTION
- `active_model_serializers` 0.10.6 upgrade.
- Replaces `has_one` with `belongs_to` avoiding loading the relation for a nice speed boost 🚀 
- 🔪 bug in `MessageSerializer` that didn't get triggered in previous versions of `active_model_serializers`
