### PR TITLE
ArbetsformedlingenAd occupation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GIT
 
 GIT
   remote: https://github.com/buren/arbetsformedlingen
-  revision: 9d5a404d409cc8a92f2a1336ea34af073755f914
+  revision: 2e5623ba0a5d1bbcedeba7da8bb5c4e17fe9a2ad
   specs:
     arbetsformedlingen (0.1.0)
       builder (~> 3.2)
@@ -234,7 +234,7 @@ GEM
     dry-container (0.6.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.3.0)
+    dry-core (0.3.1)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.0)
     dry-logic (0.4.1)

--- a/app/admin/arbetsformedlingen_ad.rb
+++ b/app/admin/arbetsformedlingen_ad.rb
@@ -12,6 +12,7 @@ ActiveAdmin.register ArbetsformedlingenAd do
       link_to(ad.id, admin_arbetsformedlingen_ad_path(ad))
     end
     column :published
+    column :occupation
     column :job
     column :updated_at do |ad|
       link_to(datetime_ago_in_words(ad.updated_at), admin_arbetsformedlingen_ad_path(ad))
@@ -23,6 +24,7 @@ ActiveAdmin.register ArbetsformedlingenAd do
     attributes_table do
       row :id
       row :job
+      row :occupation
       row :published
       row :updated_at
       row :created_at
@@ -46,6 +48,18 @@ ActiveAdmin.register ArbetsformedlingenAd do
         end
       end
     end
+  end
+
+  form do |f|
+    f.semantic_errors
+
+    f.inputs(f.object.display_name) do
+      f.input :job, collection: Job.with_translations
+      f.input :occupation, collection: Arbetsformedlingen::OccupationCode.to_form_array(name_only: true) # rubocop:disable Metrics/LineLength
+      f.input :published
+    end
+
+    f.actions
   end
 
   member_action :create_with_job, method: :get do
@@ -81,6 +95,6 @@ ActiveAdmin.register ArbetsformedlingenAd do
   end
 
   permit_params do
-    %i(job_id published)
+    %i(job_id published occupation)
   end
 end

--- a/app/models/arbetsformedlingen/job_wrapper.rb
+++ b/app/models/arbetsformedlingen/job_wrapper.rb
@@ -4,9 +4,9 @@ module Arbetsformedlingen
   class JobWrapper
     attr_reader :packet
 
-    def initialize(job, published:)
-      @job = job
-      @published = published
+    def initialize(arbetsformedlingen_ad)
+      @arbetsformedlingen_ad = arbetsformedlingen_ad
+      @job = arbetsformedlingen_ad.job
       @af_models = {}
 
       @packet = build_packet
@@ -26,7 +26,7 @@ module Arbetsformedlingen
 
     private
 
-    attr_reader :job, :published
+    attr_reader :job, :arbetsformedlingen_ad
 
     def build_packet
       @af_models[:packet] ||= Arbetsformedlingen::Packet.new(
@@ -35,10 +35,10 @@ module Arbetsformedlingen
         position: build_position,
         attributes: {
           id: job.id,
-          active: published,
+          active: arbetsformedlingen_ad.published,
           job_id: job.to_param,
           number_to_fill: job.number_to_fill,
-          ssyk_id: job.ssyk
+          occupation: arbetsformedlingen_ad.occupation
         }
       )
     end

--- a/app/services/push_arbetsformedlingen_ad_service.rb
+++ b/app/services/push_arbetsformedlingen_ad_service.rb
@@ -6,7 +6,7 @@ class PushArbetsformedlingenAdService
   def self.call(arbetsformedlingen_ad)
     ad = arbetsformedlingen_ad
 
-    wrapper = Arbetsformedlingen::JobWrapper.new(ad.job, published: ad.published)
+    wrapper = Arbetsformedlingen::JobWrapper.new(ad)
     return Result.new(wrapper.errors, nil) unless wrapper.valid?
 
     response = Arbetsformedlingen.post_job(wrapper.packet)

--- a/db/migrate/20170612084341_add_occupation_to_arbetsformedlingen_ad.rb
+++ b/db/migrate/20170612084341_add_occupation_to_arbetsformedlingen_ad.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOccupationToArbetsformedlingenAd < ActiveRecord::Migration[5.1]
+  def change
+    add_column :arbetsformedlingen_ads, :occupation, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170609123827) do
+ActiveRecord::Schema.define(version: 20170612084341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20170609123827) do
     t.boolean "published", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "occupation"
     t.index ["job_id"], name: "index_arbetsformedlingen_ads_on_job_id"
   end
 

--- a/spec/factories/arbetsformedlingen_ad_factory.rb
+++ b/spec/factories/arbetsformedlingen_ad_factory.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
   factory :arbetsformedlingen_ad do
     association :job
     published false
+    occupation 'Arkitekt'
   end
 end
 

--- a/spec/factories/arbetsformedlingen_ad_factory.rb
+++ b/spec/factories/arbetsformedlingen_ad_factory.rb
@@ -16,6 +16,7 @@ end
 #  published  :boolean          default(FALSE)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  occupation :string
 #
 # Indexes
 #

--- a/spec/models/arbetsformedlingen_ad_spec.rb
+++ b/spec/models/arbetsformedlingen_ad_spec.rb
@@ -5,17 +5,16 @@ require 'rails_helper'
 RSpec.describe ArbetsformedlingenAd, type: :model do
   describe '#validate_job_data_for_arbetsformedlingen' do
     it 'adds error if the job data is *not* valid for Arbetsformedlingen' do
-      category = FactoryGirl.build(:category, ssyk: nil)
-      job = FactoryGirl.build(:job, category: category)
+      job = FactoryGirl.build(:job, number_to_fill: nil)
       ad = FactoryGirl.build(:arbetsformedlingen_ad, job: job, published: true)
       ad.validate
-      expect(ad.errors.messages[:job]).to include('category ssyk must be filled')
+      expect(ad.errors.messages[:job]).to include('number to fill must be filled')
     end
 
     it 'adds *no* error if the job data is valid for Arbetsformedlingen' do
       ad = FactoryGirl.build(:arbetsformedlingen_ad)
       ad.validate
-      expect(ad.errors.messages[:job]).not_to include('ssyk must be filled')
+      expect(ad.errors).to be_empty
     end
   end
 end

--- a/spec/models/arbetsformedlingen_ad_spec.rb
+++ b/spec/models/arbetsformedlingen_ad_spec.rb
@@ -29,6 +29,7 @@ end
 #  published  :boolean          default(FALSE)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  occupation :string
 #
 # Indexes
 #


### PR DESCRIPTION
Update `arbetsformedlingen` gem that moves from using `ssyk` to using Arbetsförmedlingens own classification: `OccupationNameID`.