### PR TITLE
Job preview key

### DIFF
--- a/app/admin/job.rb
+++ b/app/admin/job.rb
@@ -180,11 +180,32 @@ ActiveAdmin.register Job do
   end
 
   sidebar :data_checklist, only: %i(show edit) do
-    h3 I18n.t('admin.job.checklist_sidebar.missing_translations')
     div do
-      strong(
-        (%w(en sv ar) - job.translations.map(&:locale).compact).join(', ')
+      safe_join(
+        [
+          strong(I18n.t('admin.job.checklist_sidebar.published')),
+          status_tag(job.published?)
+        ]
       )
+    end
+
+    div do
+      safe_join(
+        [
+          strong(I18n.t('admin.job.checklist_sidebar.preview_key')),
+          status_tag(job.preview_key.presence)
+        ]
+      )
+    end
+
+    missing_translations = %w(en sv ar) - job.translations.map(&:locale).compact
+    if missing_translations.any?
+      h3 I18n.t('admin.job.checklist_sidebar.missing_translations')
+      div do
+        strong(
+          missing_translations.join(', ')
+        )
+      end
     end
 
     hr
@@ -264,7 +285,7 @@ ActiveAdmin.register Job do
       :company_contact_user_id, :just_arrived_contact_user_id, :municipality,
       :number_to_fill, :order_id, :full_time, :swedish_drivers_license, :car_required,
       :publish_on_linkedin, :publish_on_blocketjobb, :blocketjobb_category,
-      :salary_type,
+      :salary_type, :preview_key,
       job_skills_attributes: %i(skill_id proficiency proficiency_by_admin),
       job_languages_attributes: %i(language_id proficiency proficiency_by_admin)
     ]

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -204,6 +204,12 @@ module Api
           )
         end
 
+        scope = if key = params[:preview_key].presence
+                  scope.where(preview_key: key)
+                else
+                  scope.published
+                end
+
         @job = scope.find(params[:job_id])
       end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -119,11 +119,16 @@ class Job < ApplicationRecord
     dates_scope = last_app_at_scope.or(before(:job_date, Time.zone.now))
     dates_scope.or(filled.or(cancelled))
   })
+  scope :without_preview_key, (lambda {
+    where(preview_key: [nil, '']).or(where(preview_key: ''))
+  })
   scope :published, (lambda {
     scope = where(unpublish_at: nil).
       or(after(:unpublish_at, Time.zone.now))
 
-    scope.visible.where.not(publish_at: nil).
+    scope.visible.
+      without_preview_key.
+      where.not(publish_at: nil).
       before(:publish_at, Time.zone.now)
   })
   scope :linkedin_jobs, (lambda {
@@ -234,6 +239,8 @@ class Job < ApplicationRecord
 
   def published?
     return false if publish_at.nil?
+    return false if preview_key.present?
+
     now = Time.zone.now
 
     publish_in_past = publish_at < now
@@ -574,6 +581,7 @@ end
 #  tasks_description            :text
 #  applicant_description        :text
 #  requirements_description     :text
+#  preview_key                  :string
 #
 # Indexes
 #

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -120,7 +120,7 @@ class Job < ApplicationRecord
     dates_scope.or(filled.or(cancelled))
   })
   scope :without_preview_key, (lambda {
-    where(preview_key: [nil, '']).or(where(preview_key: ''))
+    where(preview_key: [nil, ''])
   })
   scope :published, (lambda {
     scope = where(unpublish_at: nil).

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -212,6 +212,7 @@ end
 #  tasks_description            :text
 #  applicant_description        :text
 #  requirements_description     :text
+#  preview_key                  :string
 #
 # Indexes
 #

--- a/app/views/admin/jobs/_form.html.arb
+++ b/app/views/admin/jobs/_form.html.arb
@@ -6,6 +6,7 @@ f.inputs(I18n.t('admin.job.form.detail_section_title')) do
   f.input :job_date, as: :date_time_picker
   f.input :job_end_date, as: :date_time_picker
   f.input :last_application_at, as: :date_time_picker
+  f.input :preview_key, hint: I18n.t('admin.job.form.preview_key_hint')
   # If the job has *not* been saved then set the current
   # time as the publish date
   f.object.publish_at = Time.zone.now unless f.object.persisted?

--- a/app/views/admin/jobs/_show.html.arb
+++ b/app/views/admin/jobs/_show.html.arb
@@ -41,6 +41,7 @@ end
 
 panel(I18n.t('admin.job.show.status_flags')) do
   attributes_table_for(job) do
+    row :preview_key
     row :featured
     row :verified
     row :upcoming

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -111,6 +111,8 @@ en:
         no_apply_message: No apply message.
     job:
       checklist_sidebar:
+        published: Published
+        preview_key: Preview key
         data_title: Data collection
         skills: Skills added
         languages: Languages added
@@ -150,6 +152,7 @@ en:
         status_section_title: Status
         hourly_pay_hint: 'The hourly pay, you can add more Hourly Pays if you want under "Settings"'
         language_hint: 'Language that the job information is written in'
+        preview_key_hint: If set, the job can only be accessed with this preview key
         owner_hint: 'Job owner @ client company'
         company_contact_hint: 'Job contact @ client company, if blank owner will be used instead'
         just_arrived_contact_hint: 'The responsible user @ Just Arrived'
@@ -264,8 +267,8 @@ en:
         ongoing_jobs: Ongoing jobs
         future_jobs: Future jobs
         rejected: Rejected
-        no_skills_added: No languages added.
-        no_languages_added: No skills added.
+        no_skills_added: No skills added.
+        no_languages_added: No languages added.
     send_employment_certificate:
       post_btn: Send employment certificate
       msg: Request for employment certificate sent. The user will receive an email from Frilans Finans.

--- a/db/migrate/20170628093346_add_preview_key_to_jobs.rb
+++ b/db/migrate/20170628093346_add_preview_key_to_jobs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPreviewKeyToJobs < ActiveRecord::Migration[5.1]
+  def change
+    add_column :jobs, :preview_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170626090335) do
+ActiveRecord::Schema.define(version: 20170628093346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -564,6 +564,7 @@ ActiveRecord::Schema.define(version: 20170626090335) do
     t.text "tasks_description"
     t.text "applicant_description"
     t.text "requirements_description"
+    t.string "preview_key"
     t.index ["category_id"], name: "index_jobs_on_category_id"
     t.index ["hourly_pay_id"], name: "index_jobs_on_hourly_pay_id"
     t.index ["language_id"], name: "index_jobs_on_language_id"

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -67,6 +67,27 @@ RSpec.describe Api::V1::JobsController, type: :controller do
       get :show, params: { job_id: job.to_param }
       expect(assigns(:job)).to eq(job)
     end
+
+    context 'job with preview key' do
+      it 'assigns the requested job as @job if the correct preview key is provided' do
+        key = 'nososecret'
+        job = FactoryGirl.create(:job, preview_key: key)
+        get :show, params: { job_id: job.to_param, preview_key: key }
+        expect(assigns(:job)).to eq(job)
+      end
+
+      it 'returns 404 if the no preview key is provided' do
+        job = FactoryGirl.create(:job, preview_key: 'nososecret')
+        get :show, params: { job_id: job.to_param }
+        expect(response.status).to eq(404)
+      end
+
+      it 'returns 404 if the incorrect preview key is provided' do
+        job = FactoryGirl.create(:job, preview_key: 'nososecret')
+        get :show, params: { job_id: job.to_param, preview_key: 'wrongpreviewkey' }
+        expect(response.status).to eq(404)
+      end
+    end
   end
 
   describe 'POST #create' do
@@ -301,6 +322,7 @@ end
 #  tasks_description            :text
 #  applicant_description        :text
 #  requirements_description     :text
+#  preview_key                  :string
 #
 # Indexes
 #

--- a/spec/factories/job_factory.rb
+++ b/spec/factories/job_factory.rb
@@ -187,6 +187,7 @@ end
 #  tasks_description            :text
 #  applicant_description        :text
 #  requirements_description     :text
+#  preview_key                  :string
 #
 # Indexes
 #

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe Job, type: :model do
         )
         expect(job.published?).to eq(expected)
       end
+
+      it 'returns false if preview key is present' do
+        job = FactoryGirl.build(:job, preview_key: 'notsosecret')
+        expect(job.published?).to eq(false)
+      end
     end
   end
 
@@ -727,6 +732,7 @@ end
 #  tasks_description            :text
 #  applicant_description        :text
 #  requirements_description     :text
+#  preview_key                  :string
 #
 # Indexes
 #

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -61,6 +61,7 @@ end
 #  tasks_description            :text
 #  applicant_description        :text
 #  requirements_description     :text
+#  preview_key                  :string
 #
 # Indexes
 #

--- a/spec/routing/jobs_routing_spec.rb
+++ b/spec/routing/jobs_routing_spec.rb
@@ -83,6 +83,7 @@ end
 #  tasks_description            :text
 #  applicant_description        :text
 #  requirements_description     :text
+#  preview_key                  :string
 #
 # Indexes
 #

--- a/spec/serializers/job_serializer_spec.rb
+++ b/spec/serializers/job_serializer_spec.rb
@@ -129,6 +129,7 @@ end
 #  tasks_description            :text
 #  applicant_description        :text
 #  requirements_description     :text
+#  preview_key                  :string
 #
 # Indexes
 #


### PR DESCRIPTION
- Used to allow customers to preview jobs before they're published
- If a preview key is present on the job the job can not be displayed unless the preview key is present