### PR TITLE
Fix issue where markdown links would be auto-linked before conversion to HTML

### DIFF
--- a/lib/markdowner.rb
+++ b/lib/markdowner.rb
@@ -10,8 +10,8 @@ module Markdowner
 
   def self.to_html(markdown)
     sanitized_markdown = HTMLSanitizer.sanitize(markdown)
-    autolinked_markdown = Rinku.auto_link(sanitized_markdown)
-    Kramdown::Document.new(autolinked_markdown, input: 'GFM').to_html
+    html = Kramdown::Document.new(sanitized_markdown, input: 'GFM').to_html
+    Rinku.auto_link(html)
   end
 
   def self.to_markdown(html)

--- a/spec/lib/markdowner_spec.rb
+++ b/spec/lib/markdowner_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Markdowner do
       expected = "<p><a href=\"http://www.example.com\">www.example.com</a></p>\n"
       expect(Markdowner.to_html(markdown)).to eq(expected)
     end
+
+    it 'converts markdown, with links, to HTML and autolinks' do
+      markdown = '[example.com](http://example.com) www.example.com'
+      expected = "<p><a href=\"http://example.com\">example.com</a> <a href=\"http://www.example.com\">www.example.com</a></p>\n" # rubocop:disable Metrics/LineLength
+      expect(Markdowner.to_html(markdown)).to eq(expected)
+    end
   end
 
   describe '::to_markdown' do


### PR DESCRIPTION
We now perform the auto-linking _after_ the markdown input has been converted to HTML.

Closes #1218