### PR TITLE
API: Fallback on HTTP referrer request header if referrer is not set …

### DIFF
--- a/app/controllers/api/v1/jobs/job_users_controller.rb
+++ b/app/controllers/api/v1/jobs/job_users_controller.rb
@@ -159,7 +159,9 @@ module Api
         def job_user_attributes
           @job_user_attributes ||= begin
             attributes = policy(@job_user || JobUser.new).permitted_attributes
-            jsonapi_params.permit(attributes)
+            permitted = jsonapi_params.permit(attributes)
+            return permitted if permitted[:http_referrer].presence
+            permitted.merge(http_referrer: request.referer)
           end
         end
 

--- a/spec/controllers/jobs/job_users_controller_spec.rb
+++ b/spec/controllers/jobs/job_users_controller_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Api::V1::Jobs::JobUsersController, type: :controller do
       context 'with referrer and utm data' do
         let(:language) { FactoryGirl.create(:language) }
 
-        it 'creates a apply message' do
+        it 'creates a job user with referrer & UTM data' do
           user = FactoryGirl.create(:user_with_tokens)
           user1 = FactoryGirl.create(:company_user)
           job = FactoryGirl.create(:job, owner: user1)
@@ -153,16 +153,46 @@ RSpec.describe Api::V1::Jobs::JobUsersController, type: :controller do
               }
             }
           }
+          request_http_referrer = 'http://example.com'
+          @request.env['HTTP_REFERER'] = request_http_referrer
+
           post :create, params: params
           job_user = assigns(:job_user)
           job_user.reload
           expect(job_user).to be_a(JobUser)
           expect(job_user.http_referrer).to eq('http_referrer')
+          # Make sure that the param overrides the HTTP header
+          expect(job_user.http_referrer).not_to eq(request_http_referrer)
           expect(job_user.utm_term).to eq('utm_term')
           expect(job_user.utm_source).to eq('utm_source')
           expect(job_user.utm_medium).to eq('utm_medium')
           expect(job_user.utm_content).to eq('utm_content')
           expect(job_user.utm_campaign).to eq('utm_campaign')
+        end
+
+        it 'creates a job user with referrer from request' do
+          user = FactoryGirl.create(:user_with_tokens)
+          user1 = FactoryGirl.create(:company_user)
+          job = FactoryGirl.create(:job, owner: user1)
+          params = {
+            auth_token: user.auth_token,
+            job_id: job.to_param,
+            user: { id: user.to_param },
+            data: {
+              attributes: {
+                utm_source: 'utm_source'
+              }
+            }
+          }
+          http_referrer = 'http://example.com'
+          @request.env['HTTP_REFERER'] = http_referrer
+
+          post :create, params: params
+          job_user = assigns(:job_user)
+          job_user.reload
+          expect(job_user).to be_a(JobUser)
+          expect(job_user.http_referrer).to eq(http_referrer)
+          expect(job_user.utm_source).to eq('utm_source')
         end
       end
 


### PR DESCRIPTION
Import old:

```ruby
require 'csv'
require 'json'
require 'open-uri'

file = open('<GIST URL>').read.to_s;nil

csv = CSV.parse(file);nil

rows = csv[1..-1].map do |row|
  json = JSON.parse(row[4])
  http_referrer = json['referer']
  next if http_referrer.blank?

  user_id = json['true_user_id']
  job_id = json['path'].split('/jobs/').last.split('/').first

  job_user = JobUser.find_by(job_id: job_id, user_id: user_id)
  next if job_user.nil?
  next if job_user.http_referrer.present?

  job_user.update(http_referrer: http_referrer) if http_referrer.present?
  job_user
end.compact;nil
```