### PR TITLE
Unpublish metrojobb on job end date instead of job start date

### DIFF
--- a/app/models/metrojobb/job_wrapper.rb
+++ b/app/models/metrojobb/job_wrapper.rb
@@ -51,7 +51,7 @@ module Metrojobb
     end
 
     def to_date
-      DateFormatter.new.yyyy_mm_dd(job.last_application_at || job.job_date)
+      DateFormatter.new.yyyy_mm_dd(job.last_application_at || job.job_end_date)
     end
 
     def external_logo_url


### PR DESCRIPTION
Unpublish metrojobb on job end date instead of job start date (which often is the earliest possible start date..).
Closes #1389