### PR TITLE
Script CLI

### DIFF
--- a/lib/script_cli.rb
+++ b/lib/script_cli.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# rubocop:disable Rails/Output, Rails/Exit
+class ScriptCLI
+  def initialize(noop: false, output: STDOUT)
+    @noop = noop
+    @output = output
+  end
+
+  def puts(string)
+    @output.puts(string)
+  end
+
+  def die!(message)
+    puts("[ERROR] #{message}")
+    exit(1)
+  end
+
+  def system_call(command)
+    puts("$ #{command}")
+    return '' if noop?
+
+    `#{command}`
+  end
+
+  def noop?
+    @noop
+  end
+end
+# rubocop:enable Rails/Output, Rails/Exit

--- a/script/deploy
+++ b/script/deploy
@@ -1,22 +1,55 @@
-#!/bin/bash
-set -euo pipefail
-IFS=$'\n\t'
+#!/usr/bin/env ruby
 
-cd "$(dirname "$0")/.."
+# frozen_string_literal: true
 
 # script/deploy: Deploy the application.
 
-die () {
-  echo >&2 "$@"
-  exit 1
-}
+# Parse CLI arguments
+require 'optparse'
 
-[ "$#" -eq 1 ] || die "first argument <remote> required, $# provided"
-remote="$1"
+options = {}
+# rubocop:disable Metrics/LineLength
+OptionParser.new do |parser|
+  parser.banner = 'Usage: script/deploy --help'
+  parser.default_argv = ARGV
 
-echo -e "\n== Deploying application to $remote =="
-git push "$remote" master
-heroku run rails db:migrate --remote="$remote"
+  parser.on('--remote=production', String, 'The remote to deploy to (default: production).') do |value|
+    options[:remote] = value
+  end
 
-script/trackdeploy
-echo -e '\n== Deploy done =='
+  parser.on('--branch=master', String, 'The local branch you want to deploy (default: master).') do |value|
+    options[:branch] = value
+  end
+
+  parser.on('--[no-]db-migrate', 'Run database migrations (default: true).') do |value|
+    options[:db_migrate] = value
+  end
+
+  parser.on('-h', '--help', 'How to use') do
+    puts parser
+    exit
+  end
+end.parse!
+# rubocop:enable Metrics/LineLength
+
+remote = options.fetch(:remote, 'production')
+branch = options.fetch(:branch, 'master')
+db_migrate = options.fetch(:db_migrate, true)
+
+# Main
+require_relative '../lib/script_cli'
+
+cli = ScriptCLI.new
+cli.puts "== Deploying application - #{branch} to #{remote} =="
+
+# deploy code to Heroku
+cli.system_call("git push #{remote} #{branch}:master")
+
+# run migrations
+if db_migrate
+  cli.system_call("heroku run rails db:migrate --remote #{remote}")
+end
+
+# cli.system_call('script/trackdeploy')
+
+cli.puts "== Application deployed - #{branch} to #{remote} =="

--- a/script/deploy
+++ b/script/deploy
@@ -17,12 +17,20 @@ OptionParser.new do |parser|
     options[:remote] = value
   end
 
-  parser.on('--branch=master', String, 'The local branch you want to deploy (default: master).') do |value|
+  parser.on('--tag=v1.0.0', String, 'The local tag you want to deploy.') do |value|
+    options[:tag] = value
+  end
+
+  parser.on('--branch=master', String, 'The local branch you want to deploy.') do |value|
     options[:branch] = value
   end
 
   parser.on('--[no-]db-migrate', 'Run database migrations (default: true).') do |value|
     options[:db_migrate] = value
+  end
+
+  parser.on('--[no-]track-deploy', 'Track deploy (default: true).') do |value|
+    options[:track_deploy] = value
   end
 
   parser.on('-h', '--help', 'How to use') do
@@ -32,24 +40,30 @@ OptionParser.new do |parser|
 end.parse!
 # rubocop:enable Metrics/LineLength
 
-remote = options.fetch(:remote, 'production')
-branch = options.fetch(:branch, 'master')
-db_migrate = options.fetch(:db_migrate, true)
-
 # Main
 require_relative '../lib/script_cli'
+require_relative '../config/version'
 
 cli = ScriptCLI.new
-cli.puts "== Deploying application - #{branch} to #{remote} =="
+tag = options.fetch(:tag, "v#{JustMatch::VERSION}")
 
-# deploy code to Heroku
-cli.system_call("git push #{remote} #{branch}:master")
+remote = options.fetch(:remote, 'production')
+branch = options.fetch(:branch, nil)
+db_migrate = options.fetch(:db_migrate, true)
+track_deploy = options.fetch(:track_deploy, true)
 
-# run migrations
+cli.puts "== Deploying application - #{branch || tag} to #{remote} (migrate: #{db_migrate}) ==" # rubocop:disable Metrics/LineLength
+
+# NOTE: heroku needs ^{} custom syntax when deploying from a git tag
+branch_or_tag = branch || "#{tag}^{}"
+cli.system_call("git push --force #{remote} #{branch_or_tag}:master")
+
 if db_migrate
   cli.system_call("heroku run rails db:migrate --remote #{remote}")
 end
 
-# cli.system_call('script/trackdeploy')
+if track_deploy
+  cli.system_call('script/trackdeploy')
+end
 
-cli.puts "== Application deployed - #{branch} to #{remote} =="
+cli.puts "== Application deployed - #{branch || tag} to #{remote} =="

--- a/script/release
+++ b/script/release
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+require_relative '../lib/script_cli'
+cli = ScriptCLI.new
+
+cli.puts '== Creating application release =='
+
+require_relative '../config/version'
+version = JustMatch::VERSION
+
+# check git status
+status = cli.system_call('git status --porcelain')
+%w[config/version.rb CHANGELOG.md README.md LICENSE].each do |file|
+  if status.lines.detect { |line| line.include?(file) }
+    cli.die!("#{file} must be commited - please add and commit the file and try again")
+  end
+end
+
+# make sure we have all tags published on default remote
+cli.system_call('git fetch --tags')
+
+# get all git tags
+tags = cli.system_call('git tag --list')
+if tags.split("\n").include?("v#{version}")
+  cli.die!('Version already exists - please bump version constant(s) in config/version.rb if you wish to create a new release.') # rubocop:disable Metrics/LineLength
+end
+
+# create a new git tag
+cli.system_call("git tag -a v#{version} -m 'Version #{version}'")
+
+# push git tag to default remote
+cli.system_call('git push --tags')
+
+cli.puts '== Application release created =='


### PR DESCRIPTION
Makes it simpler and safer to create releases and deploy.

---

- `ScriptCLI` - helper class for scripts
-  `script/release` - create and publish a release
- `script/deploy` - proper CLI
  + deploy tag or branch
  + deploy w/ or w/o database migrations
  + ⚠️ deploys to production with migrations by default
