### PR TITLE
Remove typo "You account has.." => "Your account has..."

### DIFF
--- a/config/locales/mailers/mailers.en.yml
+++ b/config/locales/mailers/mailers.en.yml
@@ -128,11 +128,11 @@ en:
       login_line: Click the button below to login at Just Arrived
       login_cta: Login at Just Arrived
     full_anonymization_queued:
-      subject: You account has been marked for anonymization.
+      subject: Your account has been marked for anonymization.
       body: |
         Hi,
 
-        You account has been marked for anonymization.
+        Your account has been marked for anonymization.
 
         Your account will be fully anonymized on %{anonymization_date}. Please note that until then you might receive emails from us. During this time you can also contact us and stop the anonymization if you for some reason change your mind.
 
@@ -143,11 +143,11 @@ en:
         Sincerely,
         Team Just Arrived
     partial_anonymization_queued:
-      subject: You account has been marked for partial anonymization.
+      subject: Your account has been marked for partial anonymization.
       body: |
         Hi,
 
-        You account has been marked for anonymization.
+        Your account has been marked for anonymization.
 
         HOWEVER, please note that we're not allowed to fully anonymize your account, since you last applied for a job on %{last_application_date} and Swedish law states that we must keep applicant data for a few years.
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it 'renders the subject' do
-      expect(mail.subject).to eql('You account has been marked for anonymization.')
+      expect(mail.subject).to eql('Your account has been marked for anonymization.')
     end
 
     it 'renders the receiver email' do
@@ -183,7 +183,7 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it 'renders the subject' do
-      subject = 'You account has been marked for partial anonymization.'
+      subject = 'Your account has been marked for partial anonymization.'
       expect(mail.subject).to eql(subject)
     end
 


### PR DESCRIPTION
🔪 typo "You account has.." => "Your account has..."